### PR TITLE
🔥 fix (deleting unnecessary etherscan spec for eth mainnet)

### DIFF
--- a/chain/foundry.toml
+++ b/chain/foundry.toml
@@ -8,7 +8,6 @@ optimism_goerli = "${OPTIMISM_GOERLI_RPC_URL}"
 local = "${LOCAL_RPC_URL}"
 
 [etherscan]
-mainnet_etherscan = { key = "${ETHERSCAN_ETHEREUM_API_KEY}" }
 optimism_goerli_etherscan = { key = "${ETHERSCAN_OPTIMISM_API_KEY}", chain = "goerli" }
 
 


### PR DESCRIPTION
## What?

Deleting mainnet etherscan to fix forge deploy local. When deploying to eth mainnet, it can be re-added with the proper chain name

## Why?

It was causing a deployment bug to local anvil instance.

## Screenshots (optional)

