### PR TITLE
feat (improve-main-routes) allows for manifest to be uploaded, validates and inserts to DB

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,14 @@
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "axios": "^1.4.0",
+        "busboy": "^1.6.0",
         "date-fns": "^2.28.0",
         "dotenv": "^16.3.1",
         "ethers": "^5.7.2",
         "express": "^4.18.2",
         "mongoose": "^7.4.2",
-        "solc": "^0.8.20"
+        "solc": "^0.8.20",
+        "yauzl": "^2.10.0"
     },
     "browserslist": [
         "defaults",

--- a/src/chain-operations/transactionListener.js
+++ b/src/chain-operations/transactionListener.js
@@ -4,7 +4,7 @@ import { convertManyToDecimal, toDecimal } from "../utils/convertToFixedPointDec
 import { updateStakeholderById, updateStockClassById } from "../db/operations/update.js";
 
 async function startOnchainListeners(chain) {
-    console.log("🌐| Initiating on-chain event listeners... Stand by.");
+    console.log("🌐| Initiating on-chain event listeners...");
 
     const { contract, provider } = await getContractInstance(chain);
 

--- a/src/db/scripts/seed.js
+++ b/src/db/scripts/seed.js
@@ -1,4 +1,10 @@
-import readAndParseJSON from "../../utils/readAndParseJson.js";
+import issuerSchema from "../../../ocf/schema/objects/Issuer.schema.json" assert { type: "json" };
+import stakeholderSchema from "../../../ocf/schema/objects/Stakeholder.schema.json" assert { type: "json" };
+import stockClassSchema from "../../../ocf/schema/objects/StockClass.schema.json" assert { type: "json" };
+import stockLegendTemplateSchema from "../../../ocf/schema/objects/StockLegendTemplate.schema.json" assert { type: "json" };
+import stockPlanSchema from "../../../ocf/schema/objects/StockPlan.schema.json" assert { type: "json" };
+import valuationSchema from "../../../ocf/schema/objects/Valuation.schema.json" assert { type: "json" };
+import vestingTermsSchema from "../../../ocf/schema/objects/VestingTerms.schema.json" assert { type: "json" };
 import {
     createIssuer,
     createStakeholder,
@@ -9,36 +15,63 @@ import {
     createVestingTerms,
 } from "../operations/create.js";
 import addTransactions from "../operations/transactions.js"; // Import addTransactions
-import inputManifest from "../samples/notPoet/Manifest.ocf.json" assert { type: "json" };
 
-async function processEntity(entityFile, createEntityFunction, issuerId) {
-    const inputEntities = await readAndParseJSON(entityFile, "notPoet");
+import validateInputAgainstOCF from "../../utils/validateInputAgainstSchema.js";
+
+async function processEntity(inputEntities, createEntityFunction, schema, issuerId) {
     console.log(`Adding ${createEntityFunction.name.replace("create", "")} to DB`);
     for (let inputEntity of inputEntities.items) {
+        await validateInputAgainstOCF(inputEntity, schema);
         inputEntity = { ...inputEntity, issuer: issuerId };
         const entity = await createEntityFunction(inputEntity);
         console.log(`${createEntityFunction.name.replace("create", "")} added `, entity);
     }
 }
 
-async function addNotPoetToDB() {
-    const issuer = await createIssuer(inputManifest.issuer);
+// 1. process issuer, save to DB
+// 2. process other files, save to DB
+// 3. process transactions, save to DB
+// 4. mint cap table
+// 5. on IssuerCreated event, create the stakeholders, stock classes, etc onchain
+// 6. on IssuerCreated event, mint transactions with DB data. Save again on those events
+
+async function seedDB(manifestArr) {
+    let incomingIssuer;
+    let incomingStakeholders;
+    let incomingStockClasses;
+    let incomingStockLegendTemplates;
+    let incomingStockPlans;
+    let incomingValuations;
+    let incomingVestingTerms;
+    let incomingTransactions;
+
+    manifestArr.forEach((file) => {
+        if (file.issuer) incomingIssuer = file.issuer;
+        if (file.file_type === "OCF_STAKEHOLDERS_FILE") incomingStakeholders = file;
+        if (file.file_type === "OCF_STOCK_CLASSES_FILE") incomingStockClasses = file;
+        if (file.file_type === "OCF_STOCK_LEGEND_TEMPLATES_FILE") incomingStockLegendTemplates = file;
+        if (file.file_type === "OCF_STOCK_PLANS_FILE") incomingStockPlans = file;
+        if (file.file_type === "OCF_VALUATIONS_FILE") incomingValuations = file;
+        if (file.file_type === "OCF_VESTING_TERMS_FILE") incomingVestingTerms = file;
+        if (file.file_type === "OCF_TRANSACTIONS_FILE") incomingTransactions = file;
+    });
+
+    await validateInputAgainstOCF(incomingIssuer, issuerSchema);
+    const issuer = await createIssuer(incomingIssuer);
 
     const issuerId = issuer._id;
 
-    await processEntity(inputManifest.stakeholders_files[0].filepath, createStakeholder, issuerId);
-    await processEntity(inputManifest.stock_classes_files[0].filepath, createStockClass, issuerId);
-    await processEntity(inputManifest.stock_legend_templates_files[0].filepath, createStockLegendTemplate, issuerId);
-    await processEntity(inputManifest.stock_plans_files[0].filepath, createStockPlan, issuerId);
-    await processEntity(inputManifest.valuations_files[0].filepath, createValuation, issuerId);
-    await processEntity(inputManifest.vesting_terms_files[0].filepath, createVestingTerms, issuerId);
+    await processEntity(incomingStakeholders, createStakeholder, stakeholderSchema, issuerId);
+    await processEntity(incomingStockClasses, createStockClass, stockClassSchema, issuerId);
+    await processEntity(incomingStockLegendTemplates, createStockLegendTemplate, stockLegendTemplateSchema, issuerId);
+    await processEntity(incomingStockPlans, createStockPlan, stockPlanSchema, issuerId);
+    await processEntity(incomingValuations, createValuation, valuationSchema, issuerId);
+    await processEntity(incomingVestingTerms, createVestingTerms, vestingTermsSchema, issuerId);
 
     // TRANSACTIONS
-    const transactionsFilePath = "Transactions.ocf.json";
-    const transactionsData = await readAndParseJSON(transactionsFilePath, "notPoet");
-    await addTransactions(transactionsData, issuerId);
+    await addTransactions(incomingTransactions, issuerId);
 
     return issuer;
 }
 
-export default addNotPoetToDB;
+export default seedDB;

--- a/src/routes/issuer.js
+++ b/src/routes/issuer.js
@@ -1,0 +1,74 @@
+import { Router } from "express";
+import { v4 as uuid } from "uuid";
+
+import issuerSchema from "../../ocf/schema/objects/Issuer.schema.json" assert { type: "json" };
+import deployCapTable from "../chain-operations/deployCapTable.js";
+import { createIssuer } from "../db/operations/create.js";
+import { countIssuers, readIssuerById } from "../db/operations/read.js";
+import { convertUUIDToBytes16 } from "../utils/convertUUID.js";
+import validateInputAgainstOCF from "../utils/validateInputAgainstSchema.js";
+
+const issuer = Router();
+
+issuer.get("/", async (req, res) => {
+    res.send(`Hello issuer!`);
+});
+
+//WIP get routes are currently fetching offchain.
+issuer.get("/id/:id", async (req, res) => {
+    const { contract } = req;
+    const { id } = req.params;
+
+    try {
+        const { issuerId, type, role } = await readIssuerById(contract, id);
+
+        res.status(200).send({ issuerId, type, role });
+    } catch (error) {
+        console.error(`error: ${error}`);
+        res.status(500).send(`${error}`);
+    }
+});
+
+issuer.get("/total-number", async (req, res) => {
+    const { contract } = req;
+
+    try {
+        const totalIssuers = await countIssuers(contract);
+        res.status(200).send(totalIssuers);
+    } catch (error) {
+        console.error(`error: ${error}`);
+        res.status(500).send(`${error}`);
+    }
+});
+
+/// @dev: TODO: Issuer does not have confirmation flag on the DB because it's used  to seed
+issuer.post("/create", async (req, res) => {
+    const { chain } = req;
+
+    try {
+        // OCF doesn't allow extra fields in their validation
+        const incomingIssuerToValidate = {
+            id: uuid(),
+            object_type: "ISSUER",
+            ...req.body,
+        };
+
+        console.log("issuer to validate", incomingIssuerToValidate);
+
+        await validateInputAgainstOCF(incomingIssuerToValidate, issuerSchema);
+
+        const issuerIdBytes16 = convertUUIDToBytes16(incomingIssuerToValidate.id);
+        const deployedTo = await deployCapTable(chain, issuerIdBytes16, incomingIssuerToValidate.legal_name);
+
+        const issuer = await createIssuer(incomingIssuerToValidate);
+
+        console.log("Issuer created offchain:", issuer);
+
+        res.status(200).send({ to: deployedTo });
+    } catch (error) {
+        console.error(`error: ${error}`);
+        res.status(500).send(`${error}`);
+    }
+});
+
+export default issuer;

--- a/src/routes/issuer.js
+++ b/src/routes/issuer.js
@@ -42,6 +42,7 @@ issuer.get("/total-number", async (req, res) => {
 });
 
 /// @dev: TODO: Issuer does not have confirmation flag on the DB because it's used  to seed
+// unsure if this route should exist or we should only onboard issuers via manifest due to how we're using the IssuerCreated event onchain.
 issuer.post("/create", async (req, res) => {
     const { chain } = req;
 

--- a/src/server.js
+++ b/src/server.js
@@ -9,6 +9,7 @@ import getContractInstance from "./chain-operations/getContractInstances.js";
 
 // Routes
 import mainRoutes from "./routes/index.js";
+import issuerRoutes from "./routes/issuer.js";
 import stakeholderRoutes from "./routes/stakeholder.js";
 import stockClassRoutes from "./routes/stockClass.js";
 import transactionRoutes from "./routes/transactions.js";
@@ -43,6 +44,7 @@ app.use(json({ limit: "50mb" }));
 app.enable("trust proxy");
 
 app.use("/", chainMiddleware, mainRoutes);
+app.use("/issuer", chainMiddleware, contractMiddleware, issuerRoutes);
 app.use("/stakeholder", contractMiddleware, stakeholderRoutes);
 app.use("/stock-class", contractMiddleware, stockClassRoutes);
 // No middleware required since these are only created offchain

--- a/src/utils/processManifest.js
+++ b/src/utils/processManifest.js
@@ -1,0 +1,61 @@
+import Busboy from "busboy";
+import yauzl from "yauzl";
+
+const processManifest = (req) => {
+    return new Promise((resolve, reject) => {
+        const arr = [];
+        const busboy = Busboy({ headers: req.headers });
+
+        busboy.on("file", (fieldname, file, filename, encoding, mimetype) => {
+            const chunks = [];
+            file.on("data", (data) => {
+                chunks.push(data);
+            });
+
+            file.on("end", () => {
+                const fileBuffer = Buffer.concat(chunks);
+                yauzl.fromBuffer(fileBuffer, { lazyEntries: true }, (err, zipfile) => {
+                    if (err) return reject(err);
+
+                    zipfile.readEntry();
+                    zipfile.on("entry", (entry) => {
+                        if (/\/$/.test(entry.fileName)) {
+                            zipfile.readEntry();
+                        } else {
+                            zipfile.openReadStream(entry, (err, readStream) => {
+                                if (err) return reject(err);
+
+                                const chunks = [];
+                                readStream.on("data", (chunk) => {
+                                    chunks.push(chunk);
+                                });
+
+                                readStream.on("end", () => {
+                                    const fileData = Buffer.concat(chunks);
+                                    arr.push(JSON.parse(fileData.toString()));
+                                    zipfile.readEntry();
+                                });
+
+                                readStream.on("error", (error) => {
+                                    reject(error);
+                                });
+                            });
+                        }
+                    });
+
+                    zipfile.on("end", () => {
+                        resolve(arr);
+                    });
+                });
+            });
+        });
+
+        busboy.on("error", (err) => {
+            reject(err);
+        });
+
+        req.pipe(busboy);
+    });
+};
+
+export default processManifest;

--- a/yarn.lock
+++ b/yarn.lock
@@ -879,12 +879,24 @@ bson@^5.4.0:
   resolved "https://registry.yarnpkg.com/bson/-/bson-5.4.0.tgz#0eea77276d490953ad8616b483298dbff07384c6"
   integrity sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==
 
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
+
 bundle-name@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bundle-name/-/bundle-name-3.0.0.tgz#ba59bcc9ac785fb67ccdbf104a2bf60c099f0e1a"
   integrity sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==
   dependencies:
     run-applescript "^5.0.0"
+
+busboy@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
+  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
+  dependencies:
+    streamsearch "^1.1.0"
 
 bytes@3.1.2:
   version "3.1.2"
@@ -1669,6 +1681,13 @@ fastq@^1.6.0:
   integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
   dependencies:
     reusify "^1.0.4"
+
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
+  dependencies:
+    pend "~1.2.0"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -2824,6 +2843,11 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -3244,6 +3268,11 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
 string-argv@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
@@ -3626,6 +3655,14 @@ yaml@^2.2.2:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.1.tgz#02fe0975d23cd441242aa7204e09fc28ac2ac33b"
   integrity sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==
+
+yauzl@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## What?

- Creates new route `mint-cap-table` and expects a zipped folder that includes all JSON files.
- Processes the file, validates all objects, mint's cap table and saves all objects to DB.
- Not currently creating stakeholder, stockClasses or transactions onchain. Waiting after we add a createMany functions onchain.
- Adds create issuer standalone route, though I'm not sure if this functionality should exist since we rely on the IssuerCreated event for seeding.

## Why?


## Screenshots (optional)

