### PR TITLE
feat(datatypes-conversion): Convert TX transaction and store off-chain

### DIFF
--- a/src/chain-operations/transactionListener.js
+++ b/src/chain-operations/transactionListener.js
@@ -46,6 +46,12 @@ async function startOnchainListeners(chain) {
     contract.on("StockIssuanceCreated", async (stock, event) => {
         console.log("StockIssuanceCreated Event Emitted!", stock.id);
 
+        // TODO: Victor to think about validation
+
+        // 1. convert all of the types into OCF types
+
+        // 2. Save the data into the database
+
         // const quantity = toDecimal(stock.quantity);
         // const sharePrice = toDecimal(stock.share_price);
 

--- a/src/chain-operations/transactionListener.js
+++ b/src/chain-operations/transactionListener.js
@@ -2,6 +2,7 @@ import getContractInstance from "./getContractInstances.js";
 import { convertBytes16ToUUID } from "../utils/convertUUID.js";
 import { convertManyToDecimal, toDecimal } from "../utils/convertToFixedPointDecimals.js";
 import { updateStakeholderById, updateStockClassById } from "../db/operations/update.js";
+import { createStockIssuance } from "../db/operations/create.js";
 
 async function startOnchainListeners(chain) {
     console.log("🌐| Initiating on-chain event listeners...");
@@ -40,75 +41,50 @@ async function startOnchainListeners(chain) {
         // console.log("quantity", quantity);
     });
 
-    // TODO: need a conversion from solidity types to OCF types.
     // @dev events return both an array and object, depending how you want to access. We're using objects
-    // TODO: the conversion functions are not working properly, need to fix
     contract.on("StockIssuanceCreated", async (stock, event) => {
         console.log("StockIssuanceCreated Event Emitted!", stock.id);
 
-        // TODO: Victor to think about validation
-
-        // 1. convert all of the types into OCF types
-
-        // 2. Save the data into the database
-
-        // const quantity = toDecimal(stock.quantity);
-        // const sharePrice = toDecimal(stock.share_price);
-
-        // console.log({ quantity, sharePrice });
-
-        // const id = convertBytes16ToUUID(stock.id);
-        // console.log("issuance ID converted ", id);
-
-        // const newStockDecimals = convertManyToDecimal(stock);
-        // console.log("new stock decimals ", newStockDecimals);
-        //const stockIssuance = convertBytes16ToUUID(newStockDecimals);
-
-        // console.log("stock issuance", stockIssuance);
-
-        // console.log("newStockDecimals", newStockDecimals);
-
-        return;
+        // TODO(Victor): Think about data validation
 
         const sharePriceOCF = {
-            amount: stock.share_price.toString(),
+            amount: toDecimal(stock.share_price).toString(),
             currency: "USD",
         };
+
         const block = await provider.getBlock(event.blockNumber);
         // Type represention of an ISO-8601 date, e.g. 2022-01-28
         const dateOCF = new Date(block.timestamp * 1000).toISOString().split("T")[0];
-        const costBasisOCF = stock.cost_basis.toString ? { amount: stock.cost_basis.toString(), currency: "USD" } : {};
+        const costBasisOCF = { amount: toDecimal(stock.cost_basis).toString(), currency: "USD" }
+        const share_numbers_issuedOCF = [{
+            starting_share_number: toDecimal(stock.share_numbers_issued.starting_share_number).toString(),
+            ending_share_number: toDecimal(stock.share_numbers_issued.ending_share_number).toString()
+        }]
 
-        // data validation
+        const createdStockIssuance = await createStockIssuance({
+            _id: convertBytes16ToUUID(stock.id),
+            object_type: stock.object_type,
+            stock_class_id: convertBytes16ToUUID(stock.stock_class_id),
+            stock_plan_id: convertBytes16ToUUID(stock.stock_plan_id),
+            share_numbers_issued: share_numbers_issuedOCF,
+            share_price: sharePriceOCF,
+            quantity: toDecimal(stock.quantity).toString(),
+            vesting_terms_id: convertBytes16ToUUID(stock.vesting_terms_id),
+            cost_basis: costBasisOCF,
+            stock_legend_ids: convertBytes16ToUUID(stock.stock_legend_ids),
+            issuance_type: stock.issuance_type,
+            comments: stock.comments,
+            security_id: convertBytes16ToUUID(stock.security_id),
+            date: dateOCF,
+            custom_id: convertBytes16ToUUID(stock.custom_id), // is this uuid or custom id
+            stakeholder_id: convertBytes16ToUUID(stock.stakeholder_id),
+            board_approval_date: stock.board_approval_date,
+            stockholder_approval_date: stock.stockholder_approval_date,
+            consideration_text: stock.consideration_text,
+            security_law_exemptions: stock.security_law_exemptions,
+        });
 
-        //const stockIssuance = convertBytes16ToUUID(stock);
-
-        // const createdStockIssuance = await prisma.stockIssuance.create({
-        //     data: {
-        //         id: stockIssuance.id,
-        //         object_type: stockIssuance.object_type,
-        //         stock_class_id: stockIssuance.stock_class_id,
-        //         stock_plan_id: stockIssuance.stock_plan_id,
-        //         share_numbers_issued: stockIssuance.share_numbers_issued.toString(), // OCF structure is [{}], check how it returns
-        //         share_price: sharePriceOCF,
-        //         quantity: stock.quantity.toString(),
-        //         vesting_terms_id: stockIssuance.vesting_terms_id,
-        //         cost_basis: costBasisOCF,
-        //         stock_legend_ids: stockIssuance.stock_legend_ids,
-        //         issuance_type: stockIssuance.issuance_type,
-        //         comments: stockIssuance.comments,
-        //         security_id: stockIssuance.security_id,
-        //         date: dateOCF,
-        //         custom_id: stockIssuance.custom_id,
-        //         stakeholder_id: stockIssuance.stakeholder_id,
-        //         board_approval_date: stockIssuance.board_approval_date,
-        //         stockholder_approval_date: stockIssuance.stockholder_approval_date,
-        //         consideration_text: stockIssuance.consideration_text,
-        //         security_law_exemptions: stockIssuance.security_law_exemptions,
-        //     },
-        // });
-
-        console.log("New Stock Issuance Object Created !", createdStockIssuance);
+        console.log("Stock created off-chain", createdStockIssuance);
     });
 }
 

--- a/src/db/objects/transactions/issuance/StockIssuance.js
+++ b/src/db/objects/transactions/issuance/StockIssuance.js
@@ -26,6 +26,7 @@ const StockIssuanceSchema = new mongoose.Schema({
         type: String,
         ref: "Issuer",
     },
+    is_onchain_synced: { type: Boolean, default: false },
 });
 
 const StockIssuance = mongoose.model("StockIssuance", StockIssuanceSchema);

--- a/src/db/operations/create.js
+++ b/src/db/operations/create.js
@@ -5,6 +5,7 @@ import StockLegendTemplate from "../objects/StockLegendTemplate.js";
 import StockPlan from "../objects/StockPlan.js";
 import Valuation from "../objects/Valuation.js";
 import VestingTerms from "../objects/VestingTerms.js";
+import StockIssuance from "../objects/transactions/issuance/StockIssuance.js";
 
 export const createIssuer = (issuerData) => {
     const issuer = new Issuer(issuerData);
@@ -40,3 +41,8 @@ export const createVestingTerms = (vestingTermsData) => {
     const vestingTerms = new VestingTerms(vestingTermsData);
     return vestingTerms.save();
 };
+
+export const createStockIssuance = (stockIssuanceData) => {
+    const stockIssuance = new StockIssuance(stockIssuanceData);
+    return stockIssuance.save();
+}

--- a/src/routes/transactions.js
+++ b/src/routes/transactions.js
@@ -3,20 +3,24 @@ import { v4 as uuid } from "uuid";
 import stockIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/StockIssuance.schema.json" assert { type: "json" };
 import { convertAndCreateIssuanceStockOnchain } from "../db/controllers/transactions/issuanceController.js";
 import { convertAndCreateTransferStockOnchain } from "../db/controllers/transactions/transferController.js";
+import { readIssuerById } from "../db/operations/read.js";
 import validateInputAgainstOCF from "../utils/validateInputAgainstSchema.js";
 
 const transactions = Router();
 
 transactions.post("/issuance/stock", async (req, res) => {
     const { contract } = req;
+    const { issuerId, data } = req.body;
 
     try {
+        const issuer = await readIssuerById(issuerId);
+
         const incomingStockIssuance = {
             id: uuid(),
             security_id: uuid(),
             date: new Date().toISOString().slice(0, 10),
             object_type: "TX_STOCK_ISSUANCE",
-            ...req.body,
+            ...data,
         };
 
         await validateInputAgainstOCF(incomingStockIssuance, stockIssuanceSchema);


### PR DESCRIPTION
## What?

- [x] Convert types into OCF [schema](https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/blob/main/schema/objects/transactions/issuance/StockIssuance.schema.json) types 
## Why?

This finalizes the [TAB-183](https://linear.app/poetnetworkhq/issue/TAP-183/mapping-transaction-fields-conversion-offchain) feature, which involves converting StockIssuance types to the OCF StockIssuance schema. The final step involves storing this data off-chain.
