### PR TITLE
feat(default-AP-seeding): Add default date for AP on seeding in case it doesn't exists

### DIFF
--- a/src/state-machines/stock.js
+++ b/src/state-machines/stock.js
@@ -62,7 +62,7 @@ export const stockMachine = createMachine(
 
 const updateContext = (context, _) => {
     // console.log("context inside of updateContext ", context);
-    const { stakeholder_id, stock_class_id, security_id, quantity, share_price, date } = context.value;
+    const { stakeholder_id, stock_class_id, security_id, quantity, share_price, date = new Date() } = context.value;
 
     //Update Active Positions
     // if active position is empty for this stakeholder, create it


### PR DESCRIPTION
## What?

[TAP-261 ](https://linear.app/poetnetworkhq/issue/TAP-261/tx-dates-should-read-from-manifest-during-seeding-create-new-date)TX dates should read from manifest during seeding, create new date otherwise.

## Why?

To have the current date as default in case there is no date provided on the manifest.

## Screenshots (optional)

