### PR TITLE
Reduce number of function params with structs

### DIFF
--- a/chain/src/CapTable.sol
+++ b/chain/src/CapTable.sol
@@ -287,28 +287,12 @@ contract CapTable is ICapTable, AccessControlDefaultAdminRules {
     }
 
     /// @inheritdoc ICapTable
-    function repurchaseStock(
-        StockParamsQuantity memory params,
-        // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-        // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
-        // bytes16 securityId,
-        // string[] memory comments,
-        // string memory considerationText,
-        // uint256 quantity,
-        uint256 price
-    ) external override onlyAdmin {
+    function repurchaseStock(StockParamsQuantity memory params, uint256 price) external override onlyAdmin {
         require(stakeholderIndex[params.stakeholderId] > 0, "No stakeholder");
         require(stockClassIndex[params.stockClassId] > 0, "Invalid stock class");
 
         StockRepurchaseLib.repurchaseStockByTA(
             params,
-            // nonce,
-            // stakeholderId,
-            // stockClassId,
-            // securityId,
-            // comments,
-            // considerationText,
-            // quantity,
             price,
             positions,
             activeSecs,
@@ -319,11 +303,6 @@ contract CapTable is ICapTable, AccessControlDefaultAdminRules {
     }
 
     /// @inheritdoc ICapTable
-    // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-    // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
-    // bytes16 securityId,
-    // string[] memory comments,
-    // string memory reasonText
     function retractStockIssuance(StockParams memory params) external override onlyAdmin {
         require(stakeholderIndex[params.stakeholderId] > 0, "No stakeholder");
         require(stockClassIndex[params.stockClassId] > 0, "Invalid stock class");
@@ -340,24 +319,14 @@ contract CapTable is ICapTable, AccessControlDefaultAdminRules {
     }
 
     /// @inheritdoc ICapTable
-    // bytes16 securityId,
-    // string[] memory comments,
-    // string memory reasonText
     function reissueStock(
         StockParams memory params,
-        // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-        // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
         bytes16[] memory resulting_security_ids
     ) external override {
         StockReissuanceLib.reissueStockByTA(
             params,
             nonce,
-            // stakeholderId,
-            // stockClassId,
-            // comments,
-            // securityId,
             resulting_security_ids,
-            // reasonText,
             positions,
             activeSecs,
             transactions,
@@ -369,29 +338,15 @@ contract CapTable is ICapTable, AccessControlDefaultAdminRules {
     /// @inheritdoc ICapTable
     // Missed date here. Make sure it's recorded where it needs to be (in the struct)
     // TODO: dates seem to be missing in a handful of places, go back and recheck
-    // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-    // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
-    // bytes16 securityId,
-    // string[] memory comments,
-    // string memory reasonText,
-    // uint256 quantity
     function cancelStock(StockParamsQuantity memory params) external override onlyAdmin {
         require(stakeholderIndex[params.stakeholderId] > 0, "No stakeholder");
         require(stockClassIndex[params.stockClassId] > 0, "Invalid stock class");
 
         // need a require for activePositions
 
-        // StockParams memory params = StockParams(nonce, quantity, stakeholderId, stockClassId, securityId);
         params.nonce = nonce;
         StockCancellationLib.cancelStockByTA(
             params,
-            // nonce,
-            // stakeholderId,
-            // stockClassId,
-            // securityId,
-            // comments,
-            // reasonText,
-            // quantity,
             positions,
             activeSecs,
             transactions,

--- a/chain/src/CapTable.sol
+++ b/chain/src/CapTable.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import "openzeppelin-contracts/contracts/utils/math/SafeMath.sol";
 import { AccessControlDefaultAdminRules } from "openzeppelin-contracts/contracts/access/AccessControlDefaultAdminRules.sol";
 import { ICapTable } from "./ICapTable.sol";
-import { Issuer, Stakeholder, StockClass, ActivePositions, SecIdsStockClass, StockLegendTemplate } from "./lib/Structs.sol";
+import { StockTransferTransferParams, Issuer, Stakeholder, StockClass, ActivePositions, SecIdsStockClass, StockLegendTemplate, StockParams, StockParamsQuantity } from "./lib/Structs.sol";
 import "./lib/transactions/StockIssuance.sol";
 import "./lib/transactions/StockTransfer.sol";
 import "./lib/transactions/StockCancellation.sol";
@@ -234,24 +234,24 @@ contract CapTable is ICapTable, AccessControlDefaultAdminRules {
 
     /// @inheritdoc ICapTable
     // TODO: small syntax but change this to issueStock
+    // string memory boardApprovalDate,
+    // string memory stockholderApprovalDate,
+    // string memory considerationText,
+    // string[] memory securityLawExemptions
     function issueStockByTA(
         bytes16 stockClassId,
-        bytes16 stockPlanId,
-        ShareNumbersIssued memory shareNumbersIssued,
+        // bytes16 stockPlanId,
+        // ShareNumbersIssued memory shareNumbersIssued,
         uint256 sharePrice,
         uint256 quantity,
-        bytes16 vestingTermsId,
-        uint256 costBasis,
-        bytes16[] memory stockLegendIds,
+        // bytes16 vestingTermsId,
+        // uint256 costBasis,
+        // bytes16[] memory stockLegendIds,
         string memory issuanceType,
-        string[] memory comments,
-        string memory customId,
-        bytes16 stakeholderId,
-        string memory boardApprovalDate,
-        string memory stockholderApprovalDate,
-        string memory considerationText,
-        string[] memory securityLawExemptions
-    ) external override onlyAdmin {
+        // string[] memory comments,
+        // string memory customId,
+        bytes16 stakeholderId
+    ) external onlyAdmin {
         require(stakeholderIndex[stakeholderId] > 0, "No stakeholder");
         require(stockClassIndex[stockClassId] > 0, "Invalid stock class");
 
@@ -263,21 +263,21 @@ contract CapTable is ICapTable, AccessControlDefaultAdminRules {
         StockIssuanceLib.createStockIssuanceByTA(
             nonce,
             stockClassId,
-            stockPlanId,
-            shareNumbersIssued,
+            // stockPlanId,
+            // shareNumbersIssued,
             sharePrice,
             quantity,
-            vestingTermsId,
-            costBasis,
-            stockLegendIds,
+            // vestingTermsId,
+            // costBasis,
+            // stockLegendIds,
             issuanceType,
-            comments,
-            customId,
+            // comments,
+            // customId,
             stakeholderId,
-            boardApprovalDate,
-            stockholderApprovalDate,
-            considerationText,
-            securityLawExemptions,
+            // boardApprovalDate,
+            // stockholderApprovalDate,
+            // considerationText,
+            // securityLawExemptions,
             positions,
             activeSecs,
             transactions,
@@ -288,114 +288,115 @@ contract CapTable is ICapTable, AccessControlDefaultAdminRules {
 
     /// @inheritdoc ICapTable
     function repurchaseStock(
-        bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-        bytes16 stockClassId, //  not OCF, but required to fetch activePositions
-        bytes16 securityId,
-        string[] memory comments,
-        string memory considerationText,
-        uint256 quantity,
+        StockParamsQuantity memory params,
+        // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
+        // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
+        // bytes16 securityId,
+        // string[] memory comments,
+        // string memory considerationText,
+        // uint256 quantity,
         uint256 price
     ) external override onlyAdmin {
-        require(stakeholderIndex[stakeholderId] > 0, "No stakeholder");
-        require(stockClassIndex[stockClassId] > 0, "Invalid stock class");
+        require(stakeholderIndex[params.stakeholderId] > 0, "No stakeholder");
+        require(stockClassIndex[params.stockClassId] > 0, "Invalid stock class");
 
         StockRepurchaseLib.repurchaseStockByTA(
-            nonce,
-            stakeholderId,
-            stockClassId,
-            securityId,
-            comments,
-            considerationText,
-            quantity,
+            params,
+            // nonce,
+            // stakeholderId,
+            // stockClassId,
+            // securityId,
+            // comments,
+            // considerationText,
+            // quantity,
             price,
             positions,
             activeSecs,
             transactions,
             issuer,
-            stockClasses[stockClassIndex[stockClassId] - 1]
+            stockClasses[stockClassIndex[params.stockClassId] - 1]
         );
     }
 
     /// @inheritdoc ICapTable
-    function retractStockIssuance(
-        bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-        bytes16 stockClassId, //  not OCF, but required to fetch activePositions
-        bytes16 securityId,
-        string[] memory comments,
-        string memory reasonText
-    ) external override onlyAdmin {
-        require(stakeholderIndex[stakeholderId] > 0, "No stakeholder");
-        require(stockClassIndex[stockClassId] > 0, "Invalid stock class");
+    // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
+    // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
+    // bytes16 securityId,
+    // string[] memory comments,
+    // string memory reasonText
+    function retractStockIssuance(StockParams memory params) external override onlyAdmin {
+        require(stakeholderIndex[params.stakeholderId] > 0, "No stakeholder");
+        require(stockClassIndex[params.stockClassId] > 0, "Invalid stock class");
 
         StockRetractionLib.retractStockIssuanceByTA(
+            params,
             nonce,
-            stakeholderId,
-            stockClassId,
-            securityId,
-            comments,
-            reasonText,
             positions,
             activeSecs,
             transactions,
             issuer,
-            stockClasses[stockClassIndex[stockClassId] - 1]
+            stockClasses[stockClassIndex[params.stockClassId] - 1]
         );
     }
 
     /// @inheritdoc ICapTable
+    // bytes16 securityId,
+    // string[] memory comments,
+    // string memory reasonText
     function reissueStock(
-        bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-        bytes16 stockClassId, //  not OCF, but required to fetch activePositions
-        bytes16[] memory resulting_security_ids,
-        bytes16 securityId,
-        string[] memory comments,
-        string memory reasonText
+        StockParams memory params,
+        // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
+        // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
+        bytes16[] memory resulting_security_ids
     ) external override {
         StockReissuanceLib.reissueStockByTA(
+            params,
             nonce,
-            stakeholderId,
-            stockClassId,
-            comments,
-            securityId,
+            // stakeholderId,
+            // stockClassId,
+            // comments,
+            // securityId,
             resulting_security_ids,
-            reasonText,
+            // reasonText,
             positions,
             activeSecs,
             transactions,
             issuer,
-            stockClasses[stockClassIndex[stockClassId] - 1]
+            stockClasses[stockClassIndex[params.stockClassId] - 1]
         );
     }
 
     /// @inheritdoc ICapTable
     // Missed date here. Make sure it's recorded where it needs to be (in the struct)
     // TODO: dates seem to be missing in a handful of places, go back and recheck
-    function cancelStock(
-        bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-        bytes16 stockClassId, //  not OCF, but required to fetch activePositions
-        bytes16 securityId,
-        string[] memory comments,
-        string memory reasonText,
-        uint256 quantity
-    ) external override onlyAdmin {
-        require(stakeholderIndex[stakeholderId] > 0, "No stakeholder");
-        require(stockClassIndex[stockClassId] > 0, "Invalid stock class");
+    // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
+    // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
+    // bytes16 securityId,
+    // string[] memory comments,
+    // string memory reasonText,
+    // uint256 quantity
+    function cancelStock(StockParamsQuantity memory params) external override onlyAdmin {
+        require(stakeholderIndex[params.stakeholderId] > 0, "No stakeholder");
+        require(stockClassIndex[params.stockClassId] > 0, "Invalid stock class");
 
         // need a require for activePositions
 
+        // StockParams memory params = StockParams(nonce, quantity, stakeholderId, stockClassId, securityId);
+        params.nonce = nonce;
         StockCancellationLib.cancelStockByTA(
-            nonce,
-            stakeholderId,
-            stockClassId,
-            securityId,
-            comments,
-            reasonText,
-            quantity,
+            params,
+            // nonce,
+            // stakeholderId,
+            // stockClassId,
+            // securityId,
+            // comments,
+            // reasonText,
+            // quantity,
             positions,
             activeSecs,
             transactions,
             issuer,
-            stockClasses[stockClassIndex[stockClassId] - 1]
+            stockClasses[stockClassIndex[params.stockClassId] - 1]
         );
     }
 
@@ -412,20 +413,17 @@ contract CapTable is ICapTable, AccessControlDefaultAdminRules {
         require(stakeholderIndex[transfereeStakeholderId] > 0, "No transferee");
         require(stockClassIndex[stockClassId] > 0, "Invalid stock class");
 
-        StockTransferLib.transferStock(
+        StockTransferTransferParams memory params = StockTransferTransferParams(
             transferorStakeholderId,
             transfereeStakeholderId,
             stockClassId,
             isBuyerVerified,
             quantity,
             share_price,
-            nonce,
-            positions,
-            activeSecs,
-            transactions,
-            issuer,
-            stockClasses[stockClassIndex[stockClassId] - 1]
+            nonce
         );
+
+        StockTransferLib.transferStock(params, positions, activeSecs, transactions, issuer, stockClasses[stockClassIndex[stockClassId] - 1]);
     }
 
     /* Role Based Access Control */

--- a/chain/src/ICapTable.sol
+++ b/chain/src/ICapTable.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import "openzeppelin-contracts/contracts/utils/math/SafeMath.sol";
 import { AccessControlDefaultAdminRules } from "openzeppelin-contracts/contracts/access/AccessControlDefaultAdminRules.sol";
-import { Issuer, Stakeholder, StockClass, ActivePositions, SecIdsStockClass, StockLegendTemplate, ShareNumbersIssued, StockParams, StockParamsQuantity } from "./lib/Structs.sol";
+import { Issuer, Stakeholder, StockClass, ActivePositions, SecIdsStockClass, StockLegendTemplate, ShareNumbersIssued, StockParams, StockParamsQuantity, StockIssuanceParams } from "./lib/Structs.sol";
 
 interface ICapTable {
     // @dev Transactions will be created on-chain then reflected off-chain.
@@ -66,24 +66,7 @@ interface ICapTable {
 
     function getTotalNumberOfStockClasses() external view returns (uint256);
 
-    function issueStockByTA(
-        bytes16 stockClassId,
-        // bytes16 stockPlanId,
-        // ShareNumbersIssued memory shareNumbersIssued,
-        uint256 sharePrice,
-        uint256 quantity,
-        // bytes16 vestingTermsId,
-        // uint256 costBasis,
-        // bytes16[] memory stockLegendIds,
-        string memory issuanceType,
-        // string[] memory comments,
-        // string memory customId,
-        bytes16 stakeholderId
-        // string memory boardApprovalDate,
-        // string memory stockholderApprovalDate,
-        // string memory considerationText,
-        // string[] memory securityLawExemptions
-    ) external;
+    function issueStockByTA(StockIssuanceParams memory params) external;
 
     function repurchaseStock(StockParamsQuantity memory params, uint256 price) external;
 

--- a/chain/src/ICapTable.sol
+++ b/chain/src/ICapTable.sol
@@ -85,45 +85,13 @@ interface ICapTable {
         // string[] memory securityLawExemptions
     ) external;
 
-    function repurchaseStock(
-        StockParamsQuantity memory params,
-        // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-        // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
-        // bytes16 securityId,
-        // string[] memory comments,
-        // string memory considerationText,
-        // uint256 quantity,
-        uint256 price
-    ) external;
+    function repurchaseStock(StockParamsQuantity memory params, uint256 price) external;
 
-    function retractStockIssuance(
-        StockParams memory params
-        // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-        // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
-        // bytes16 securityId,
-        // string[] memory comments,
-        // string memory reasonText
-    ) external;
+    function retractStockIssuance(StockParams memory params) external;
 
-    function reissueStock(
-        StockParams memory params,
-        // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-        // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
-        bytes16[] memory resulting_security_ids
-        // bytes16 securityId,
-        // string[] memory comments,
-        // string memory reasonText
-    ) external;
+    function reissueStock(StockParams memory params, bytes16[] memory resulting_security_ids) external;
 
-    function cancelStock(
-        StockParamsQuantity memory paramsQuantity
-        // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-        // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
-        // bytes16 securityId,
-        // string[] memory comments,
-        // string memory reasonText,
-        // uint256 quantity
-    ) external;
+    function cancelStock(StockParamsQuantity memory paramsQuantity) external;
 
     function transferStock(
         bytes16 transferorStakeholderId,

--- a/chain/src/ICapTable.sol
+++ b/chain/src/ICapTable.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import "openzeppelin-contracts/contracts/utils/math/SafeMath.sol";
 import { AccessControlDefaultAdminRules } from "openzeppelin-contracts/contracts/access/AccessControlDefaultAdminRules.sol";
-import { Issuer, Stakeholder, StockClass, ActivePositions, SecIdsStockClass, StockLegendTemplate, ShareNumbersIssued } from "./lib/Structs.sol";
+import { Issuer, Stakeholder, StockClass, ActivePositions, SecIdsStockClass, StockLegendTemplate, ShareNumbersIssued, StockParams, StockParamsQuantity } from "./lib/Structs.sol";
 
 interface ICapTable {
     // @dev Transactions will be created on-chain then reflected off-chain.
@@ -68,57 +68,61 @@ interface ICapTable {
 
     function issueStockByTA(
         bytes16 stockClassId,
-        bytes16 stockPlanId,
-        ShareNumbersIssued memory shareNumbersIssued,
+        // bytes16 stockPlanId,
+        // ShareNumbersIssued memory shareNumbersIssued,
         uint256 sharePrice,
         uint256 quantity,
-        bytes16 vestingTermsId,
-        uint256 costBasis,
-        bytes16[] memory stockLegendIds,
+        // bytes16 vestingTermsId,
+        // uint256 costBasis,
+        // bytes16[] memory stockLegendIds,
         string memory issuanceType,
-        string[] memory comments,
-        string memory customId,
-        bytes16 stakeholderId,
-        string memory boardApprovalDate,
-        string memory stockholderApprovalDate,
-        string memory considerationText,
-        string[] memory securityLawExemptions
+        // string[] memory comments,
+        // string memory customId,
+        bytes16 stakeholderId
+        // string memory boardApprovalDate,
+        // string memory stockholderApprovalDate,
+        // string memory considerationText,
+        // string[] memory securityLawExemptions
     ) external;
 
     function repurchaseStock(
-        bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-        bytes16 stockClassId, //  not OCF, but required to fetch activePositions
-        bytes16 securityId,
-        string[] memory comments,
-        string memory considerationText,
-        uint256 quantity,
+        StockParamsQuantity memory params,
+        // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
+        // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
+        // bytes16 securityId,
+        // string[] memory comments,
+        // string memory considerationText,
+        // uint256 quantity,
         uint256 price
     ) external;
 
     function retractStockIssuance(
-        bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-        bytes16 stockClassId, //  not OCF, but required to fetch activePositions
-        bytes16 securityId,
-        string[] memory comments,
-        string memory reasonText
+        StockParams memory params
+        // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
+        // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
+        // bytes16 securityId,
+        // string[] memory comments,
+        // string memory reasonText
     ) external;
 
     function reissueStock(
-        bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-        bytes16 stockClassId, //  not OCF, but required to fetch activePositions
-        bytes16[] memory resulting_security_ids,
-        bytes16 securityId,
-        string[] memory comments,
-        string memory reasonText
+        StockParams memory params,
+        // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
+        // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
+        bytes16[] memory resulting_security_ids
+        // bytes16 securityId,
+        // string[] memory comments,
+        // string memory reasonText
     ) external;
 
     function cancelStock(
-        bytes16 stakeholderId, // not OCF, but required to fetch activePositions
-        bytes16 stockClassId, //  not OCF, but required to fetch activePositions
-        bytes16 securityId,
-        string[] memory comments,
-        string memory reasonText,
-        uint256 quantity
+        StockParamsQuantity memory paramsQuantity
+        // bytes16 stakeholderId, // not OCF, but required to fetch activePositions
+        // bytes16 stockClassId, //  not OCF, but required to fetch activePositions
+        // bytes16 securityId,
+        // string[] memory comments,
+        // string memory reasonText,
+        // uint256 quantity
     ) external;
 
     function transferStock(

--- a/chain/src/lib/Structs.sol
+++ b/chain/src/lib/Structs.sol
@@ -167,7 +167,7 @@ struct StockParams {
 struct StockTransferTransferParams {
     bytes16 transferorStakeholderId;
     bytes16 transfereeStakeholderId;
-    bytes16 stockClassId; // TODO: verify that we would have fong would have the stock class
+    bytes16 stockClassId;
     bool isBuyerVerified;
     uint256 quantity;
     uint256 share_price;

--- a/chain/src/lib/Structs.sol
+++ b/chain/src/lib/Structs.sol
@@ -161,21 +161,21 @@ struct StockTransferTransferParams {
 
 struct StockIssuanceParams {
     bytes16 stockClassId;
-    bytes16 stockPlanId;
-    ShareNumbersIssued shareNumbersIssued;
-    uint256 sharePrice;
-    uint256 quantity;
-    bytes16 vestingTermsId;
-    uint256 costBasis;
-    bytes16[] stockLegendIds;
-    string issuanceType;
-    string[] comments;
-    string customId;
+    bytes16 stockPlanId; // Optional
+    ShareNumbersIssued shareNumbersIssued; // Optional
+    uint256 sharePrice; // OCF Monetary (USD is all that matters). Amount is Numeric: Fixed-point string representation of a number (up to 10 decimal places supported)
+    uint256 quantity; // Numeric: Fixed-point string representation of a number (up to 10 decimal places supported)
+    bytes16 vestingTermsId; // Optional
+    uint256 costBasis; // Optional OCF Monetary (USD is all that matters). Amount is Numeric: Fixed-point string representation of a number (up to 10 decimal places supported)
+    bytes16[] stockLegendIds; // Optional
+    string issuanceType; // Optional for special types (["RSA", "FOUNDERS_STOCK"],)
+    string[] comments; // Optional
+    string customId; // Optional (eg R2-D2)
     bytes16 stakeholderId;
-    string boardApprovalDate;
-    string stockholderApprovalDate;
-    string considerationText;
-    string[] securityLawExemptions;
+    string boardApprovalDate; // Optional
+    string stockholderApprovalDate; // Optional
+    string considerationText; // Optional
+    string[] securityLawExemptions; // Unclear
 }
 
 // date fields are going to use block timestamp

--- a/chain/src/lib/Structs.sol
+++ b/chain/src/lib/Structs.sol
@@ -106,23 +106,8 @@ struct StockClassAuthorizedSharesAdjustment {
 struct StockIssuance {
     bytes16 id;
     string object_type;
-    bytes16 stock_class_id;
-    // bytes16 stock_plan_id; // Optional
-    // ShareNumbersIssued share_numbers_issued; // Optional
-    uint256 share_price; // OCF Monetary (USD is all that matters). Amount is  Numeric: Fixed-point string representation of a number (up to 10 decimal places supported)
-    uint256 quantity; // Numeric: Fixed-point string representation of a number (up to 10 decimal places supported)
-    // bytes16 vesting_terms_id; // Optional
-    // uint256 cost_basis; // Optional OCF Monetary (USD is all that matters). Amount is  Numeric: Fixed-point string representation of a number (up to 10 decimal places supported)
-    // bytes16[] stock_legend_ids; // Optional
-    string issuance_type; // Optional for special types (["RSA", "FOUNDERS_STOCK"],)
-    // string[] comments; // Optional
     bytes16 security_id;
-    // string custom_id; // Optional (eg R2-D2)
-    bytes16 stakeholder_id;
-    // string board_approval_date; // Optional
-    // string stockholder_approval_date; // Optional
-    // string consideration_text; // Optional
-    // string[] security_law_exemptions; // Unclear
+    StockIssuanceParams params;
 }
 
 /*
@@ -172,6 +157,25 @@ struct StockTransferTransferParams {
     uint256 quantity;
     uint256 share_price;
     uint256 nonce;
+}
+
+struct StockIssuanceParams {
+    bytes16 stockClassId;
+    bytes16 stockPlanId;
+    ShareNumbersIssued shareNumbersIssued;
+    uint256 sharePrice;
+    uint256 quantity;
+    bytes16 vestingTermsId;
+    uint256 costBasis;
+    bytes16[] stockLegendIds;
+    string issuanceType;
+    string[] comments;
+    string customId;
+    bytes16 stakeholderId;
+    string boardApprovalDate;
+    string stockholderApprovalDate;
+    string considerationText;
+    string[] securityLawExemptions;
 }
 
 // date fields are going to use block timestamp

--- a/chain/src/lib/Structs.sol
+++ b/chain/src/lib/Structs.sol
@@ -107,22 +107,22 @@ struct StockIssuance {
     bytes16 id;
     string object_type;
     bytes16 stock_class_id;
-    bytes16 stock_plan_id; // Optional
-    ShareNumbersIssued share_numbers_issued; // Optional
+    // bytes16 stock_plan_id; // Optional
+    // ShareNumbersIssued share_numbers_issued; // Optional
     uint256 share_price; // OCF Monetary (USD is all that matters). Amount is  Numeric: Fixed-point string representation of a number (up to 10 decimal places supported)
     uint256 quantity; // Numeric: Fixed-point string representation of a number (up to 10 decimal places supported)
-    bytes16 vesting_terms_id; // Optional
-    uint256 cost_basis; // Optional OCF Monetary (USD is all that matters). Amount is  Numeric: Fixed-point string representation of a number (up to 10 decimal places supported)
-    bytes16[] stock_legend_ids; // Optional
+    // bytes16 vesting_terms_id; // Optional
+    // uint256 cost_basis; // Optional OCF Monetary (USD is all that matters). Amount is  Numeric: Fixed-point string representation of a number (up to 10 decimal places supported)
+    // bytes16[] stock_legend_ids; // Optional
     string issuance_type; // Optional for special types (["RSA", "FOUNDERS_STOCK"],)
-    string[] comments; // Optional
+    // string[] comments; // Optional
     bytes16 security_id;
-    string custom_id; // Optional (eg R2-D2)
+    // string custom_id; // Optional (eg R2-D2)
     bytes16 stakeholder_id;
-    string board_approval_date; // Optional
-    string stockholder_approval_date; // Optional
-    string consideration_text; // Optional
-    string[] security_law_exemptions; // Unclear
+    // string board_approval_date; // Optional
+    // string stockholder_approval_date; // Optional
+    // string consideration_text; // Optional
+    // string[] security_law_exemptions; // Unclear
 }
 
 /*
@@ -144,6 +144,34 @@ struct StockIssuance {
 
 struct StockLegendTemplate {
     bytes16 id;
+}
+
+struct StockParamsQuantity {
+    uint256 nonce;
+    uint256 quantity;
+    bytes16 stakeholderId;
+    bytes16 stockClassId;
+    bytes16 securityId;
+    string[] comments;
+    string reasonText;
+}
+
+struct StockParams {
+    bytes16 stakeholderId; // not OCF, but required to fetch activePositions
+    bytes16 stockClassId; //  not OCF, but required to fetch activePositions
+    bytes16 securityId;
+    string[] comments;
+    string reasonText;
+}
+
+struct StockTransferTransferParams {
+    bytes16 transferorStakeholderId;
+    bytes16 transfereeStakeholderId;
+    bytes16 stockClassId; // TODO: verify that we would have fong would have the stock class
+    bool isBuyerVerified;
+    uint256 quantity;
+    uint256 share_price;
+    uint256 nonce;
 }
 
 // date fields are going to use block timestamp

--- a/chain/src/lib/TxHelper.sol
+++ b/chain/src/lib/TxHelper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import { StockIssuance, StockTransfer, StockRepurchase, ShareNumbersIssued, StockAcceptance, StockCancellation, StockReissuance, StockRetraction, IssuerAuthorizedSharesAdjustment, StockClassAuthorizedSharesAdjustment, StockTransferTransferParams, StockParamsQuantity } from "./Structs.sol";
+import { StockIssuance, StockIssuanceParams, StockTransfer, StockRepurchase, ShareNumbersIssued, StockAcceptance, StockCancellation, StockReissuance, StockRetraction, IssuerAuthorizedSharesAdjustment, StockClassAuthorizedSharesAdjustment, StockTransferTransferParams, StockParamsQuantity } from "./Structs.sol";
 
 library TxHelper {
     function generateDeterministicUniqueID(bytes16 stakeholderId, uint256 nonce) public view returns (bytes16) {
@@ -9,56 +9,11 @@ library TxHelper {
         return deterministicValue;
     }
 
-    function createStockIssuanceStructByTA(
-        uint256 nonce,
-        bytes16 stockClassId,
-        // bytes16 stockPlanId,
-        // ShareNumbersIssued memory shareNumbersIssued,
-        uint256 sharePrice,
-        uint256 quantity,
-        // bytes16 vestingTermsId,
-        // uint256 costBasis,
-        // bytes16[] memory stockLegendIds,
-        string memory issuanceType,
-        // string[] memory comments,
-        // string memory customId,
-        bytes16 stakeholderId
-    )
-        internal
-        view
-        returns (
-            // string memory boardApprovalDate,
-            // string memory stockholderApprovalDate,
-            // string memory considerationText,
-            // string[] memory securityLawExemptions
-            StockIssuance memory issuance
-        )
-    {
-        bytes16 id = generateDeterministicUniqueID(stakeholderId, nonce);
-        bytes16 secId = generateDeterministicUniqueID(stockClassId, nonce);
+    function createStockIssuanceStructByTA(uint256 nonce, StockIssuanceParams memory params) internal view returns (StockIssuance memory issuance) {
+        bytes16 id = generateDeterministicUniqueID(params.stakeholderId, nonce);
+        bytes16 secId = generateDeterministicUniqueID(params.stockClassId, nonce);
 
-        return
-            StockIssuance(
-                id,
-                "TX_STOCK_ISSUANCE",
-                stockClassId,
-                // stockPlanId,
-                // shareNumbersIssued,
-                sharePrice,
-                quantity,
-                // vestingTermsId,
-                // costBasis,
-                // stockLegendIds,
-                issuanceType,
-                // comments,
-                secId,
-                // customId,
-                stakeholderId
-                // boardApprovalDate,
-                // stockholderApprovalDate,
-                // considerationText,
-                // securityLawExemptions
-            );
+        return StockIssuance(id, "TX_STOCK_ISSUANCE", secId, params);
     }
 
     // TODO: do we need to have more information from the previous transferor issuance in this new issuance?
@@ -72,28 +27,30 @@ library TxHelper {
         bytes16 id = generateDeterministicUniqueID(stakeholderId, transferParams.nonce);
         bytes16 securityId = generateDeterministicUniqueID(transferParams.stockClassId, transferParams.nonce);
 
+        StockIssuanceParams memory params = StockIssuanceParams(
+            transferParams.stockClassId, // Stock class ID
+            "", // Stock plan ID (optional)
+            share_numbers_issued, // Share numbers issued (optional)
+            transferParams.share_price, // Share price
+            transferParams.quantity, // Quantity
+            "", // Vesting terms ID (optional)
+            0e10, // Cost basis (optional)
+            new bytes16[](0), // Stock legend IDs (optional)
+            "", // Issuance type (optional)
+            new string[](0), // Comments
+            "", // Custom ID (optional)
+            stakeholderId, // Stakeholder ID
+            "", // Board approval date (optional)
+            "", // Stockholder approval date (optional)
+            "", // Consideration text (optional)
+            new string[](0) // Security law exemptions (optional)
+        );
         return
             StockIssuance(
                 id, // ID
                 "TX_STOCK_ISSUANCE", // Transaction type
-                transferParams.stockClassId, // Stock class ID
-                // "", // Stock plan ID (optional)
-                // share_numbers_issued, // Share numbers issued (optional)
-                // sharePrice, // Share price
-                transferParams.share_price, // Share price
-                transferParams.quantity, // Quantity
-                // "", // Vesting terms ID (optional)
-                // 0e10, // Cost basis (optional)
-                // new bytes16[](0), // Stock legend IDs (optional)
-                "", // Issuance type (optional)
-                // new string[](0), // Comments
                 securityId, // Security ID
-                // "", // Custom ID (optional)
-                stakeholderId // Stakeholder ID
-                // "", // Board approval date (optional)
-                // "", // Stockholder approval date (optional)
-                // "", // Consideration text (optional)
-                // new string[](0) // Security law exemptions (optional)
+                params
             );
     }
 

--- a/chain/src/lib/TxHelper.sol
+++ b/chain/src/lib/TxHelper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import { StockIssuance, StockTransfer, StockRepurchase, ShareNumbersIssued, StockAcceptance, StockCancellation, StockReissuance, StockRetraction, IssuerAuthorizedSharesAdjustment, StockClassAuthorizedSharesAdjustment, StockTransferTransferParams } from "./Structs.sol";
+import { StockIssuance, StockTransfer, StockRepurchase, ShareNumbersIssued, StockAcceptance, StockCancellation, StockReissuance, StockRetraction, IssuerAuthorizedSharesAdjustment, StockClassAuthorizedSharesAdjustment, StockTransferTransferParams, StockParamsQuantity } from "./Structs.sol";
 
 library TxHelper {
     function generateDeterministicUniqueID(bytes16 stakeholderId, uint256 nonce) public view returns (bytes16) {
@@ -63,11 +63,6 @@ library TxHelper {
 
     // TODO: do we need to have more information from the previous transferor issuance in this new issuance?
     // I think we can extend this for all other types of balances
-    // uint256 nonce,
-    // bytes16 stakeholderId,
-    // uint256 quantity,
-    // uint256 sharePrice,
-    // bytes16 stockClassId
     function createStockIssuanceStructForTransfer(
         StockTransferTransferParams memory transferParams,
         bytes16 stakeholderId
@@ -151,19 +146,21 @@ library TxHelper {
         return StockRetraction(id, "TX_STOCK_RETRACTION", comments, securityId, reasonText);
     }
 
-    function createStockRepurchaseStruct(
-        uint256 nonce,
-        // string[] memory comments,
-        bytes16 securityId,
-        string memory considerationText,
-        bytes16 balance_security_id,
-        uint256 quantity,
-        uint256 price
-    ) internal view returns (StockRepurchase memory repurchase) {
-        bytes16 id = generateDeterministicUniqueID(securityId, nonce);
+    function createStockRepurchaseStruct(StockParamsQuantity memory params, uint256 price) internal view returns (StockRepurchase memory repurchase) {
+        bytes16 id = generateDeterministicUniqueID(params.securityId, params.nonce);
 
-        string[] memory comments = new string[](0);
-        return StockRepurchase(id, "TX_STOCK_REPURCHASE", comments, securityId, considerationText, balance_security_id, quantity, price);
+        // Note: using stakeholderId to store balanceSecurityId
+        return
+            StockRepurchase(
+                id,
+                "TX_STOCK_REPURCHASE",
+                params.comments,
+                params.securityId,
+                params.reasonText,
+                params.stakeholderId,
+                params.quantity,
+                price
+            );
     }
 
     function adjustIssuerAuthorizedShares(

--- a/chain/src/lib/TxHelper.sol
+++ b/chain/src/lib/TxHelper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import { StockIssuance, StockTransfer, StockRepurchase, ShareNumbersIssued, StockAcceptance, StockCancellation, StockReissuance, StockRetraction, IssuerAuthorizedSharesAdjustment, StockClassAuthorizedSharesAdjustment } from "./Structs.sol";
+import { StockIssuance, StockTransfer, StockRepurchase, ShareNumbersIssued, StockAcceptance, StockCancellation, StockReissuance, StockRetraction, IssuerAuthorizedSharesAdjustment, StockClassAuthorizedSharesAdjustment, StockTransferTransferParams } from "./Structs.sol";
 
 library TxHelper {
     function generateDeterministicUniqueID(bytes16 stakeholderId, uint256 nonce) public view returns (bytes16) {
@@ -12,22 +12,28 @@ library TxHelper {
     function createStockIssuanceStructByTA(
         uint256 nonce,
         bytes16 stockClassId,
-        bytes16 stockPlanId,
-        ShareNumbersIssued memory shareNumbersIssued,
+        // bytes16 stockPlanId,
+        // ShareNumbersIssued memory shareNumbersIssued,
         uint256 sharePrice,
         uint256 quantity,
-        bytes16 vestingTermsId,
-        uint256 costBasis,
-        bytes16[] memory stockLegendIds,
+        // bytes16 vestingTermsId,
+        // uint256 costBasis,
+        // bytes16[] memory stockLegendIds,
         string memory issuanceType,
-        string[] memory comments,
-        string memory customId,
-        bytes16 stakeholderId,
-        string memory boardApprovalDate,
-        string memory stockholderApprovalDate,
-        string memory considerationText,
-        string[] memory securityLawExemptions
-    ) internal view returns (StockIssuance memory issuance) {
+        // string[] memory comments,
+        // string memory customId,
+        bytes16 stakeholderId
+    )
+        internal
+        view
+        returns (
+            // string memory boardApprovalDate,
+            // string memory stockholderApprovalDate,
+            // string memory considerationText,
+            // string[] memory securityLawExemptions
+            StockIssuance memory issuance
+        )
+    {
         bytes16 id = generateDeterministicUniqueID(stakeholderId, nonce);
         bytes16 secId = generateDeterministicUniqueID(stockClassId, nonce);
 
@@ -36,60 +42,63 @@ library TxHelper {
                 id,
                 "TX_STOCK_ISSUANCE",
                 stockClassId,
-                stockPlanId,
-                shareNumbersIssued,
+                // stockPlanId,
+                // shareNumbersIssued,
                 sharePrice,
                 quantity,
-                vestingTermsId,
-                costBasis,
-                stockLegendIds,
+                // vestingTermsId,
+                // costBasis,
+                // stockLegendIds,
                 issuanceType,
-                comments,
+                // comments,
                 secId,
-                customId,
-                stakeholderId,
-                boardApprovalDate,
-                stockholderApprovalDate,
-                considerationText,
-                securityLawExemptions
+                // customId,
+                stakeholderId
+                // boardApprovalDate,
+                // stockholderApprovalDate,
+                // considerationText,
+                // securityLawExemptions
             );
     }
 
     // TODO: do we need to have more information from the previous transferor issuance in this new issuance?
     // I think we can extend this for all other types of balances
+    // uint256 nonce,
+    // bytes16 stakeholderId,
+    // uint256 quantity,
+    // uint256 sharePrice,
+    // bytes16 stockClassId
     function createStockIssuanceStructForTransfer(
-        uint256 nonce,
-        bytes16 stakeholderId,
-        uint256 quantity,
-        uint256 sharePrice,
-        bytes16 stockClassId
+        StockTransferTransferParams memory transferParams,
+        bytes16 stakeholderId
     ) internal view returns (StockIssuance memory issuance) {
         ShareNumbersIssued memory share_numbers_issued; // if not instatiated it defaults to 0 for both values
 
-        bytes16 id = generateDeterministicUniqueID(stakeholderId, nonce);
-        bytes16 securityId = generateDeterministicUniqueID(stockClassId, nonce);
+        bytes16 id = generateDeterministicUniqueID(stakeholderId, transferParams.nonce);
+        bytes16 securityId = generateDeterministicUniqueID(transferParams.stockClassId, transferParams.nonce);
 
         return
             StockIssuance(
                 id, // ID
                 "TX_STOCK_ISSUANCE", // Transaction type
-                stockClassId, // Stock class ID
-                "", // Stock plan ID (optional)
-                share_numbers_issued, // Share numbers issued (optional)
-                sharePrice, // Share price
-                quantity, // Quantity
-                "", // Vesting terms ID (optional)
-                0e10, // Cost basis (optional)
-                new bytes16[](0), // Stock legend IDs (optional)
+                transferParams.stockClassId, // Stock class ID
+                // "", // Stock plan ID (optional)
+                // share_numbers_issued, // Share numbers issued (optional)
+                // sharePrice, // Share price
+                transferParams.share_price, // Share price
+                transferParams.quantity, // Quantity
+                // "", // Vesting terms ID (optional)
+                // 0e10, // Cost basis (optional)
+                // new bytes16[](0), // Stock legend IDs (optional)
                 "", // Issuance type (optional)
-                new string[](0), // Comments
+                // new string[](0), // Comments
                 securityId, // Security ID
-                "", // Custom ID (optional)
-                stakeholderId, // Stakeholder ID
-                "", // Board approval date (optional)
-                "", // Stockholder approval date (optional)
-                "", // Consideration text (optional)
-                new string[](0) // Security law exemptions (optional)
+                // "", // Custom ID (optional)
+                stakeholderId // Stakeholder ID
+                // "", // Board approval date (optional)
+                // "", // Stockholder approval date (optional)
+                // "", // Consideration text (optional)
+                // new string[](0) // Security law exemptions (optional)
             );
     }
 
@@ -144,7 +153,7 @@ library TxHelper {
 
     function createStockRepurchaseStruct(
         uint256 nonce,
-        string[] memory comments,
+        // string[] memory comments,
         bytes16 securityId,
         string memory considerationText,
         bytes16 balance_security_id,
@@ -153,6 +162,7 @@ library TxHelper {
     ) internal view returns (StockRepurchase memory repurchase) {
         bytes16 id = generateDeterministicUniqueID(securityId, nonce);
 
+        string[] memory comments = new string[](0);
         return StockRepurchase(id, "TX_STOCK_REPURCHASE", comments, securityId, considerationText, balance_security_id, quantity, price);
     }
 

--- a/chain/src/lib/transactions/StockCancellation.sol
+++ b/chain/src/lib/transactions/StockCancellation.sol
@@ -52,16 +52,12 @@ library StockCancellationLib {
         }
 
         params.nonce++;
-        string memory reason = new string(0);
-        string[] memory comments = new string[](0);
         StockCancellation memory cancellation = TxHelper.createStockCancellationStruct(
             params.nonce,
             params.quantity,
-            comments,
-            // comments,
+            params.comments,
             params.securityId,
-            reason,
-            // params.reasonText,
+            params.reasonText,
             balance_security_id
         );
         _cancelStock(cancellation, transactions);

--- a/chain/src/lib/transactions/StockCancellation.sol
+++ b/chain/src/lib/transactions/StockCancellation.sol
@@ -15,13 +15,6 @@ library StockCancellationLib {
 
     function cancelStockByTA(
         StockParamsQuantity memory params,
-        // uint256 nonce,
-        // uint256 quantity,
-        // bytes16 stakeholderId,
-        // bytes16 stockClassId,
-        // bytes16 securityId,
-        // string[] memory comments,
-        // string memory reasonText,
         ActivePositions storage positions,
         SecIdsStockClass storage activeSecs,
         address[] storage transactions,
@@ -48,15 +41,7 @@ library StockCancellationLib {
                 activePosition.share_price,
                 params.nonce
             );
-            StockIssuance memory balanceIssuance = TxHelper.createStockIssuanceStructForTransfer(
-                transferParams,
-                transferParams.stockClassId
-                // nonce,
-                // stakeholderId,
-                // remainingQuantity,
-                // activePosition.share_price,
-                // stockClassId
-            );
+            StockIssuance memory balanceIssuance = TxHelper.createStockIssuanceStructForTransfer(transferParams, transferParams.stockClassId);
 
             StockIssuanceLib._updateContext(balanceIssuance, positions, activeSecs, issuer, stockClass);
             StockIssuanceLib._issueStock(balanceIssuance, transactions);

--- a/chain/src/lib/transactions/StockCancellation.sol
+++ b/chain/src/lib/transactions/StockCancellation.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "openzeppelin-contracts/contracts/utils/math/SafeMath.sol";
-import { StockCancellation, ActivePositions, ActivePosition, SecIdsStockClass, Issuer, StockClass } from "../Structs.sol";
+import { StockCancellation, ActivePositions, ActivePosition, SecIdsStockClass, Issuer, StockClass, StockParamsQuantity, StockTransferTransferParams } from "../Structs.sol";
 import "./StockIssuance.sol";
 import "../../transactions/StockCancellationTX.sol";
 import "../TxHelper.sol";
@@ -14,36 +14,48 @@ library StockCancellationLib {
     event StockCancellationCreated(StockCancellation cancellation);
 
     function cancelStockByTA(
-        uint256 nonce,
-        bytes16 stakeholderId,
-        bytes16 stockClassId,
-        bytes16 securityId,
-        string[] memory comments,
-        string memory reasonText,
-        uint256 quantity,
+        StockParamsQuantity memory params,
+        // uint256 nonce,
+        // uint256 quantity,
+        // bytes16 stakeholderId,
+        // bytes16 stockClassId,
+        // bytes16 securityId,
+        // string[] memory comments,
+        // string memory reasonText,
         ActivePositions storage positions,
         SecIdsStockClass storage activeSecs,
         address[] storage transactions,
         Issuer storage issuer,
         StockClass storage stockClass
     ) external {
-        ActivePosition memory activePosition = positions.activePositions[stakeholderId][securityId];
+        ActivePosition memory activePosition = positions.activePositions[params.stakeholderId][params.securityId];
 
-        require(activePosition.quantity >= quantity, "Insufficient shares");
+        require(activePosition.quantity >= params.quantity, "Insufficient shares");
 
-        uint256 remainingQuantity = activePosition.quantity - quantity;
+        uint256 remainingQuantity = activePosition.quantity - params.quantity;
         bytes16 balance_security_id;
 
         if (remainingQuantity > 0) {
             // issue balance
-            nonce++;
+            params.nonce++;
 
-            StockIssuance memory balanceIssuance = TxHelper.createStockIssuanceStructForTransfer(
-                nonce,
-                stakeholderId,
+            StockTransferTransferParams memory transferParams = StockTransferTransferParams(
+                params.stakeholderId,
+                bytes16(0),
+                params.stockClassId,
+                true,
                 remainingQuantity,
                 activePosition.share_price,
-                stockClassId
+                params.nonce
+            );
+            StockIssuance memory balanceIssuance = TxHelper.createStockIssuanceStructForTransfer(
+                transferParams,
+                transferParams.stockClassId
+                // nonce,
+                // stakeholderId,
+                // remainingQuantity,
+                // activePosition.share_price,
+                // stockClassId
             );
 
             StockIssuanceLib._updateContext(balanceIssuance, positions, activeSecs, issuer, stockClass);
@@ -54,22 +66,26 @@ library StockCancellationLib {
             balance_security_id = "";
         }
 
-        nonce++;
+        params.nonce++;
+        string memory reason = new string(0);
+        string[] memory comments = new string[](0);
         StockCancellation memory cancellation = TxHelper.createStockCancellationStruct(
-            nonce,
-            quantity,
+            params.nonce,
+            params.quantity,
             comments,
-            securityId,
-            reasonText,
+            // comments,
+            params.securityId,
+            reason,
+            // params.reasonText,
             balance_security_id
         );
         _cancelStock(cancellation, transactions);
 
-        issuer.shares_issued = issuer.shares_issued.sub(quantity);
-        stockClass.shares_issued = stockClass.shares_issued.sub(quantity);
+        issuer.shares_issued = issuer.shares_issued.sub(params.quantity);
+        stockClass.shares_issued = stockClass.shares_issued.sub(params.quantity);
 
-        DeleteContext.deleteActivePosition(stakeholderId, securityId, positions);
-        DeleteContext.deleteActiveSecurityIdsByStockClass(stakeholderId, stockClassId, securityId, activeSecs);
+        DeleteContext.deleteActivePosition(params.stakeholderId, params.securityId, positions);
+        DeleteContext.deleteActiveSecurityIdsByStockClass(params.stakeholderId, params.stockClassId, params.securityId, activeSecs);
     }
 
     function _cancelStock(StockCancellation memory cancellation, address[] storage transactions) internal {

--- a/chain/src/lib/transactions/StockIssuance.sol
+++ b/chain/src/lib/transactions/StockIssuance.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "openzeppelin-contracts/contracts/utils/math/SafeMath.sol";
-import { StockIssuance, ActivePosition, ShareNumbersIssued, ActivePositions, SecIdsStockClass, Issuer, StockClass } from "../Structs.sol";
+import { StockIssuance, ActivePosition, ShareNumbersIssued, ActivePositions, SecIdsStockClass, Issuer, StockClass, StockIssuanceParams } from "../Structs.sol";
 import "../DeterministicUUID.sol";
 import "../../transactions/StockIssuanceTX.sol";
 
@@ -14,56 +14,21 @@ library StockIssuanceLib {
     // TODO: split this up into multiple functions? e.g. call the optionals in a different function to fill out the same struct
     function createStockIssuanceByTA(
         uint256 nonce,
-        bytes16 stockClassId,
-        // bytes16 stockPlanId,
-        // ShareNumbersIssued memory shareNumbersIssued,
-        uint256 sharePrice,
-        uint256 quantity,
-        // bytes16 vestingTermsId,
-        // uint256 costBasis,
-        // bytes16[] memory stockLegendIds,
-        string memory issuanceType,
-        // string[] memory comments,
-        // string memory customId,
-        bytes16 stakeholderId,
-        // string memory boardApprovalDate,
-        // string memory stockholderApprovalDate,
-        // string memory considerationText,
-        // string[] memory securityLawExemptions,
+        StockIssuanceParams memory issuanceParams,
         ActivePositions storage positions,
         SecIdsStockClass storage activeSecs,
         address[] storage transactions,
         Issuer storage issuer,
         StockClass storage stockClass
     ) external {
-        require(quantity > 0, "Invalid quantity");
-        require(sharePrice > 0, "Invalid price");
+        require(issuanceParams.quantity > 0, "Invalid quantity");
+        require(issuanceParams.sharePrice > 0, "Invalid price");
         nonce++;
-        bytes16 id = DeterministicUUID.generateDeterministicUniqueID(stakeholderId, nonce);
+        bytes16 id = DeterministicUUID.generateDeterministicUniqueID(issuanceParams.stakeholderId, nonce);
         nonce++;
-        bytes16 secId = DeterministicUUID.generateDeterministicUniqueID(stockClassId, nonce);
+        bytes16 secId = DeterministicUUID.generateDeterministicUniqueID(issuanceParams.stockClassId, nonce);
         //TODO: Move to TX helper
-        StockIssuance memory issuance = StockIssuance(
-            id,
-            "TX_STOCK_ISSUANCE",
-            stockClassId,
-            // stockPlanId,
-            // shareNumbersIssued,
-            sharePrice,
-            quantity,
-            // vestingTermsId,
-            // costBasis,
-            // stockLegendIds,
-            issuanceType,
-            // comments,
-            secId,
-            // customId,
-            stakeholderId
-            // boardApprovalDate,
-            // stockholderApprovalDate,
-            // considerationText,
-            // securityLawExemptions
-        );
+        StockIssuance memory issuance = StockIssuance(id, "TX_STOCK_ISSUANCE", secId, issuanceParams);
         _updateContext(issuance, positions, activeSecs, issuer, stockClass);
         _issueStock(issuance, transactions);
     }
@@ -75,17 +40,17 @@ library StockIssuanceLib {
         Issuer storage issuer,
         StockClass storage stockClass
     ) internal {
-        activeSecs.activeSecurityIdsByStockClass[issuance.stakeholder_id][issuance.stock_class_id].push(issuance.security_id);
+        activeSecs.activeSecurityIdsByStockClass[issuance.params.stakeholderId][issuance.params.stockClassId].push(issuance.security_id);
 
-        positions.activePositions[issuance.stakeholder_id][issuance.security_id] = ActivePosition(
-            issuance.stock_class_id,
-            issuance.quantity,
-            issuance.share_price,
+        positions.activePositions[issuance.params.stakeholderId][issuance.security_id] = ActivePosition(
+            issuance.params.stockClassId,
+            issuance.params.quantity,
+            issuance.params.sharePrice,
             _safeNow() // TODO: only using current datetime doesn't allow us to support backfilling transactions.
         );
 
-        issuer.shares_issued = issuer.shares_issued.add(issuance.quantity);
-        stockClass.shares_issued = stockClass.shares_issued.add(issuance.quantity);
+        issuer.shares_issued = issuer.shares_issued.add(issuance.params.quantity);
+        stockClass.shares_issued = stockClass.shares_issued.add(issuance.params.quantity);
     }
 
     function _issueStock(StockIssuance memory issuance, address[] storage transactions) internal {

--- a/chain/src/lib/transactions/StockIssuance.sol
+++ b/chain/src/lib/transactions/StockIssuance.sol
@@ -11,24 +11,25 @@ library StockIssuanceLib {
 
     event StockIssuanceCreated(StockIssuance issuance);
 
+    // TODO: split this up into multiple functions? e.g. call the optionals in a different function to fill out the same struct
     function createStockIssuanceByTA(
         uint256 nonce,
         bytes16 stockClassId,
-        bytes16 stockPlanId,
-        ShareNumbersIssued memory shareNumbersIssued,
+        // bytes16 stockPlanId,
+        // ShareNumbersIssued memory shareNumbersIssued,
         uint256 sharePrice,
         uint256 quantity,
-        bytes16 vestingTermsId,
-        uint256 costBasis,
-        bytes16[] memory stockLegendIds,
+        // bytes16 vestingTermsId,
+        // uint256 costBasis,
+        // bytes16[] memory stockLegendIds,
         string memory issuanceType,
-        string[] memory comments,
-        string memory customId,
+        // string[] memory comments,
+        // string memory customId,
         bytes16 stakeholderId,
-        string memory boardApprovalDate,
-        string memory stockholderApprovalDate,
-        string memory considerationText,
-        string[] memory securityLawExemptions,
+        // string memory boardApprovalDate,
+        // string memory stockholderApprovalDate,
+        // string memory considerationText,
+        // string[] memory securityLawExemptions,
         ActivePositions storage positions,
         SecIdsStockClass storage activeSecs,
         address[] storage transactions,
@@ -37,35 +38,32 @@ library StockIssuanceLib {
     ) external {
         require(quantity > 0, "Invalid quantity");
         require(sharePrice > 0, "Invalid price");
-
         nonce++;
         bytes16 id = DeterministicUUID.generateDeterministicUniqueID(stakeholderId, nonce);
         nonce++;
         bytes16 secId = DeterministicUUID.generateDeterministicUniqueID(stockClassId, nonce);
-
         //TODO: Move to TX helper
         StockIssuance memory issuance = StockIssuance(
             id,
             "TX_STOCK_ISSUANCE",
             stockClassId,
-            stockPlanId,
-            shareNumbersIssued,
+            // stockPlanId,
+            // shareNumbersIssued,
             sharePrice,
             quantity,
-            vestingTermsId,
-            costBasis,
-            stockLegendIds,
+            // vestingTermsId,
+            // costBasis,
+            // stockLegendIds,
             issuanceType,
-            comments,
+            // comments,
             secId,
-            customId,
-            stakeholderId,
-            boardApprovalDate,
-            stockholderApprovalDate,
-            considerationText,
-            securityLawExemptions
+            // customId,
+            stakeholderId
+            // boardApprovalDate,
+            // stockholderApprovalDate,
+            // considerationText,
+            // securityLawExemptions
         );
-
         _updateContext(issuance, positions, activeSecs, issuer, stockClass);
         _issueStock(issuance, transactions);
     }

--- a/chain/src/lib/transactions/StockReissuance.sol
+++ b/chain/src/lib/transactions/StockReissuance.sol
@@ -18,12 +18,7 @@ library StockReissuanceLib {
     function reissueStockByTA(
         StockParams memory params,
         uint256 nonce,
-        // bytes16 stakeholderId,
-        // bytes16 stockClassId,
-        // string[] memory comments,
-        // bytes16 securityId,
         bytes16[] memory resulting_security_ids,
-        // string memory reason_text,
         ActivePositions storage positions,
         SecIdsStockClass storage activeSecs,
         address[] storage transactions,

--- a/chain/src/lib/transactions/StockReissuance.sol
+++ b/chain/src/lib/transactions/StockReissuance.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "openzeppelin-contracts/contracts/utils/math/SafeMath.sol";
-import { StockRepurchase, ActivePositions, ActivePosition, SecIdsStockClass, Issuer, StockClass } from "../Structs.sol";
+import { StockRepurchase, ActivePositions, ActivePosition, SecIdsStockClass, Issuer, StockClass, StockParams } from "../Structs.sol";
 import "./StockIssuance.sol";
 import "../../transactions/StockReissuanceTX.sol";
 import "../TxHelper.sol";
@@ -16,31 +16,38 @@ library StockReissuanceLib {
     event StockReissuanceCreated(StockReissuance reissuance);
 
     function reissueStockByTA(
+        StockParams memory params,
         uint256 nonce,
-        bytes16 stakeholderId,
-        bytes16 stockClassId,
-        string[] memory comments,
-        bytes16 securityId,
+        // bytes16 stakeholderId,
+        // bytes16 stockClassId,
+        // string[] memory comments,
+        // bytes16 securityId,
         bytes16[] memory resulting_security_ids,
-        string memory reason_text,
+        // string memory reason_text,
         ActivePositions storage positions,
         SecIdsStockClass storage activeSecs,
         address[] storage transactions,
         Issuer storage issuer,
         StockClass storage stockClass
     ) external {
-        ActivePosition memory activePosition = positions.activePositions[stakeholderId][securityId];
+        ActivePosition memory activePosition = positions.activePositions[params.stakeholderId][params.securityId];
 
         nonce++;
-        StockReissuance memory reissuance = TxHelper.createStockReissuanceStruct(nonce, comments, securityId, resulting_security_ids, reason_text);
+        StockReissuance memory reissuance = TxHelper.createStockReissuanceStruct(
+            nonce,
+            params.comments,
+            params.securityId,
+            resulting_security_ids,
+            params.reasonText
+        );
 
         _reissueStock(reissuance, transactions);
 
         issuer.shares_issued = issuer.shares_issued.sub(activePosition.quantity);
         stockClass.shares_issued = stockClass.shares_issued.sub(activePosition.quantity);
 
-        DeleteContext.deleteActivePosition(stakeholderId, securityId, positions);
-        DeleteContext.deleteActiveSecurityIdsByStockClass(stakeholderId, stockClassId, securityId, activeSecs);
+        DeleteContext.deleteActivePosition(params.stakeholderId, params.securityId, positions);
+        DeleteContext.deleteActiveSecurityIdsByStockClass(params.stakeholderId, params.stockClassId, params.securityId, activeSecs);
     }
 
     function _reissueStock(StockReissuance memory reissuance, address[] storage transactions) internal {

--- a/chain/src/lib/transactions/StockRepurchase.sol
+++ b/chain/src/lib/transactions/StockRepurchase.sol
@@ -15,13 +15,6 @@ library StockRepurchaseLib {
 
     function repurchaseStockByTA(
         StockParamsQuantity memory params,
-        // uint256 nonce,
-        // bytes16 stakeholderId,
-        // bytes16 stockClassId,
-        // bytes16 securityId,
-        // string[] memory comments,
-        // string memory considerationText,
-        // uint256 quantity,
         uint256 price,
         ActivePositions storage positions,
         SecIdsStockClass storage activeSecs,
@@ -49,15 +42,7 @@ library StockRepurchaseLib {
                 activePosition.share_price,
                 params.nonce
             );
-            StockIssuance memory balanceIssuance = TxHelper.createStockIssuanceStructForTransfer(
-                transferParams,
-                transferParams.stockClassId
-                // nonce,
-                // stakeholderId,
-                // remainingQuantity,
-                // activePosition.share_price,
-                // stockClassId
-            );
+            StockIssuance memory balanceIssuance = TxHelper.createStockIssuanceStructForTransfer(transferParams, transferParams.stockClassId);
 
             StockIssuanceLib._updateContext(balanceIssuance, positions, activeSecs, issuer, stockClass);
             StockIssuanceLib._issueStock(balanceIssuance, transactions);
@@ -68,16 +53,7 @@ library StockRepurchaseLib {
         }
 
         params.nonce++;
-        StockRepurchase memory repurchase = TxHelper.createStockRepurchaseStruct(
-            params.nonce,
-            // comments,
-            params.securityId,
-            "",
-            // considerationText,
-            balance_security_id,
-            params.quantity,
-            price
-        );
+        StockRepurchase memory repurchase = TxHelper.createStockRepurchaseStruct(params, price);
 
         _repurchaseStock(repurchase, transactions);
 

--- a/chain/src/lib/transactions/StockRepurchase.sol
+++ b/chain/src/lib/transactions/StockRepurchase.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "openzeppelin-contracts/contracts/utils/math/SafeMath.sol";
-import { StockRepurchase, ActivePositions, ActivePosition, SecIdsStockClass, Issuer, StockClass } from "../Structs.sol";
+import { StockRepurchase, ActivePositions, ActivePosition, SecIdsStockClass, Issuer, StockClass, StockTransferTransferParams, StockParamsQuantity } from "../Structs.sol";
 import "./StockIssuance.sol";
 import "../../transactions/StockRepurchaseTX.sol";
 import "../TxHelper.sol";
@@ -14,13 +14,14 @@ library StockRepurchaseLib {
     event StockRepurchaseCreated(StockRepurchase repurchase);
 
     function repurchaseStockByTA(
-        uint256 nonce,
-        bytes16 stakeholderId,
-        bytes16 stockClassId,
-        bytes16 securityId,
-        string[] memory comments,
-        string memory considerationText,
-        uint256 quantity,
+        StockParamsQuantity memory params,
+        // uint256 nonce,
+        // bytes16 stakeholderId,
+        // bytes16 stockClassId,
+        // bytes16 securityId,
+        // string[] memory comments,
+        // string memory considerationText,
+        // uint256 quantity,
         uint256 price,
         ActivePositions storage positions,
         SecIdsStockClass storage activeSecs,
@@ -28,23 +29,34 @@ library StockRepurchaseLib {
         Issuer storage issuer,
         StockClass storage stockClass
     ) external {
-        ActivePosition memory activePosition = positions.activePositions[stakeholderId][securityId];
+        ActivePosition memory activePosition = positions.activePositions[params.stakeholderId][params.securityId];
 
-        require(activePosition.quantity >= quantity, "Insufficient shares");
+        require(activePosition.quantity >= params.quantity, "Insufficient shares");
 
-        uint256 remainingQuantity = activePosition.quantity - quantity;
+        uint256 remainingQuantity = activePosition.quantity - params.quantity;
         bytes16 balance_security_id;
 
         if (remainingQuantity > 0) {
             // issue balance
-            nonce++;
+            params.nonce++;
 
-            StockIssuance memory balanceIssuance = TxHelper.createStockIssuanceStructForTransfer(
-                nonce,
-                stakeholderId,
+            StockTransferTransferParams memory transferParams = StockTransferTransferParams(
+                params.stakeholderId,
+                bytes16(0),
+                params.stockClassId,
+                true,
                 remainingQuantity,
                 activePosition.share_price,
-                stockClassId
+                params.nonce
+            );
+            StockIssuance memory balanceIssuance = TxHelper.createStockIssuanceStructForTransfer(
+                transferParams,
+                transferParams.stockClassId
+                // nonce,
+                // stakeholderId,
+                // remainingQuantity,
+                // activePosition.share_price,
+                // stockClassId
             );
 
             StockIssuanceLib._updateContext(balanceIssuance, positions, activeSecs, issuer, stockClass);
@@ -55,24 +67,25 @@ library StockRepurchaseLib {
             balance_security_id = "";
         }
 
-        nonce++;
+        params.nonce++;
         StockRepurchase memory repurchase = TxHelper.createStockRepurchaseStruct(
-            nonce,
-            comments,
-            securityId,
-            considerationText,
+            params.nonce,
+            // comments,
+            params.securityId,
+            "",
+            // considerationText,
             balance_security_id,
-            quantity,
+            params.quantity,
             price
         );
 
         _repurchaseStock(repurchase, transactions);
 
-        issuer.shares_issued = issuer.shares_issued.sub(quantity);
-        stockClass.shares_issued = stockClass.shares_issued.sub(quantity);
+        issuer.shares_issued = issuer.shares_issued.sub(params.quantity);
+        stockClass.shares_issued = stockClass.shares_issued.sub(params.quantity);
 
-        DeleteContext.deleteActivePosition(stakeholderId, securityId, positions);
-        DeleteContext.deleteActiveSecurityIdsByStockClass(stakeholderId, stockClassId, securityId, activeSecs);
+        DeleteContext.deleteActivePosition(params.stakeholderId, params.securityId, positions);
+        DeleteContext.deleteActiveSecurityIdsByStockClass(params.stakeholderId, params.stockClassId, params.securityId, activeSecs);
     }
 
     function _repurchaseStock(StockRepurchase memory repurchase, address[] storage transactions) internal {

--- a/chain/src/lib/transactions/StockRetraction.sol
+++ b/chain/src/lib/transactions/StockRetraction.sol
@@ -17,11 +17,6 @@ library StockRetractionLib {
     function retractStockIssuanceByTA(
         StockParams memory params,
         uint256 nonce,
-        // bytes16 stakeholderId,
-        // bytes16 stockClassId,
-        // bytes16 securityId,
-        // string[] memory comments,
-        // string memory reasonText,
         ActivePositions storage positions,
         SecIdsStockClass storage activeSecs,
         address[] storage transactions,

--- a/chain/src/lib/transactions/StockTransfer.sol
+++ b/chain/src/lib/transactions/StockTransfer.sol
@@ -15,13 +15,6 @@ library StockTransferLib {
 
     function transferStock(
         StockTransferTransferParams memory params,
-        // bytes16 transferorStakeholderId,
-        // bytes16 transfereeStakeholderId,
-        // bytes16 stockClassId, // TODO: verify that we would have fong would have the stock class
-        // bool isBuyerVerified,
-        // uint256 quantity,
-        // uint256 share_price,
-        // uint256 nonce,
         ActivePositions storage positions,
         SecIdsStockClass storage activeSecs,
         address[] storage transactions,
@@ -72,21 +65,7 @@ library StockTransferLib {
             StockTransferTransferParams memory newParams = params;
             newParams.quantity = transferQuantity;
 
-            _transferSingleStock(
-                newParams,
-                // transferorStakeholderId,
-                // transfereeStakeholderId,
-                // stockClassId,
-                // transferQuantity,
-                // share_price,
-                activeSecurityIDs[index],
-                // nonce,
-                positions,
-                activeSecs,
-                transactions,
-                issuer,
-                stockClass
-            );
+            _transferSingleStock(newParams, activeSecurityIDs[index], positions, activeSecs, transactions, issuer, stockClass);
 
             remainingQuantity -= transferQuantity; // Reduce the remaining quantity
 
@@ -100,13 +79,7 @@ library StockTransferLib {
     // isBuyerVerified is a placeholder for a signature, account or hash that confirms the buyer's identity.
     function _transferSingleStock(
         StockTransferTransferParams memory params,
-        // bytes16 transferorStakeholderId,
-        // bytes16 transfereeStakeholderId,
-        // bytes16 stockClassId,
-        // uint256 quantity,
-        // uint256 sharePrice,
         bytes16 securityId,
-        // uint256 nonce,
         ActivePositions storage positions,
         SecIdsStockClass storage activeSecs,
         address[] storage transactions,
@@ -119,16 +92,7 @@ library StockTransferLib {
         require(transferorActivePosition.quantity >= params.quantity, "Insufficient shares");
 
         params.nonce++;
-        StockIssuance memory transfereeIssuance = TxHelper.createStockIssuanceStructForTransfer(
-            // params.nonce,
-            // params.transfereeStakeholderId,
-            // params.quantity,
-            // // sharePrice,
-            // params.share_price,
-            // params.stockClassId
-            params,
-            params.stockClassId
-        );
+        StockIssuance memory transfereeIssuance = TxHelper.createStockIssuanceStructForTransfer(params, params.stockClassId);
 
         StockIssuanceLib._updateContext(transfereeIssuance, positions, activeSecs, issuer, stockClass);
         StockIssuanceLib._issueStock(transfereeIssuance, transactions);
@@ -141,15 +105,7 @@ library StockTransferLib {
         params.share_price = transferorActivePosition.share_price;
         if (balanceForTransferor > 0) {
             params.nonce++;
-            StockIssuance memory transferorBalanceIssuance = TxHelper.createStockIssuanceStructForTransfer(
-                // params.nonce,
-                // params.transferorStakeholderId,
-                // balanceForTransferor,
-                // transferorActivePosition.share_price,
-                // params.stockClassId
-                params,
-                securityId
-            );
+            StockIssuance memory transferorBalanceIssuance = TxHelper.createStockIssuanceStructForTransfer(params, securityId);
 
             StockIssuanceLib._updateContext(transferorBalanceIssuance, positions, activeSecs, issuer, stockClass);
             StockIssuanceLib._issueStock(transferorBalanceIssuance, transactions);

--- a/chain/test/Stakeholder.t.sol
+++ b/chain/test/Stakeholder.t.sol
@@ -4,15 +4,16 @@ pragma solidity ^0.8.20;
 import "./CapTable.t.sol";
 
 contract StakeholderTests is CapTableTest {
-    // function testCreateStakeholder() public {
-    //     bytes16 stakeholderId = 0xf47ac10b58cc4372a5670e02b2c3d479;
-    //     capTable.createStakeholder(stakeholderId, "INDIVIDUAL", "ADVISOR");
-    //     (bytes16 actualId, , ) = capTable.getStakeholderById(stakeholderId);
-    //     assertEq(actualId, stakeholderId);
-    // }
-    // function testCreateDuplicateStakeholderReverts() public {
-    //     bytes16 stakeholderId = 0xf47ac10b58cc4372a5670e02b2c3d479;
-    //     createPranksterAndExpectRevert();
-    //     capTable.createStakeholder(stakeholderId, "INDIVIDUAL", "ADVISOR");
-    // }
+    function testCreateStakeholder() public {
+        bytes16 stakeholderId = 0xf47ac10b58cc4372a5670e02b2c3d479;
+        capTable.createStakeholder(stakeholderId, "INDIVIDUAL", "ADVISOR");
+        (bytes16 actualId, , ) = capTable.getStakeholderById(stakeholderId);
+        assertEq(actualId, stakeholderId);
+    }
+
+    function testCreateDuplicateStakeholderReverts() public {
+        bytes16 stakeholderId = 0xf47ac10b58cc4372a5670e02b2c3d479;
+        createPranksterAndExpectRevert();
+        capTable.createStakeholder(stakeholderId, "INDIVIDUAL", "ADVISOR");
+    }
 }

--- a/chain/test/StockClass.t.sol
+++ b/chain/test/StockClass.t.sol
@@ -4,26 +4,27 @@ pragma solidity ^0.8.20;
 import "./CapTable.t.sol";
 
 contract StockClassTests is CapTableTest {
-    // function createInitialDummyStockClassData() public pure returns (bytes16, string memory, uint256, uint256) {
-    //     bytes16 expectedId = 0xd3373e0a4dd9430f8a563281f2454545;
-    //     string memory expectedClassType = "Common";
-    //     uint256 expectedPricePerShare = 10000000000; // $1.00 with 10 decimals
-    //     uint256 expectedInitialSharesAuthorized = 100000000000000000; // 10,000,000
-    //     return (expectedId, expectedClassType, expectedPricePerShare, expectedInitialSharesAuthorized);
-    // }
-    // function testCreateStockClassWithOwner() public {
-    //     (
-    //         bytes16 expectedId,
-    //         string memory expectedClassType,
-    //         uint256 expectedPricePerShare,
-    //         uint256 expectedInitialSharesAuthorized
-    //     ) = createInitialDummyStockClassData();
-    //     capTable.createStockClass(expectedId, expectedClassType, expectedPricePerShare, expectedInitialSharesAuthorized);
-    //     (bytes16 actualId, string memory actualClassType, uint256 actualPricePerShare, uint256 actualInitialSharesAuthorized) = capTable
-    //         .getStockClassById(expectedId);
-    //     assertEq(actualId, expectedId);
-    //     assertEq(actualClassType, expectedClassType);
-    //     assertEq(actualPricePerShare, expectedPricePerShare);
-    //     assertEq(actualInitialSharesAuthorized, expectedInitialSharesAuthorized);
-    // }
+    function createInitialDummyStockClassData() public pure returns (bytes16, string memory, uint256, uint256) {
+        bytes16 expectedId = 0xd3373e0a4dd9430f8a563281f2454545;
+        string memory expectedClassType = "Common";
+        uint256 expectedPricePerShare = 10000000000; // $1.00 with 10 decimals
+        uint256 expectedInitialSharesAuthorized = 100000000000000000; // 10,000,000
+        return (expectedId, expectedClassType, expectedPricePerShare, expectedInitialSharesAuthorized);
+    }
+
+    function testCreateStockClassWithOwner() public {
+        (
+            bytes16 expectedId,
+            string memory expectedClassType,
+            uint256 expectedPricePerShare,
+            uint256 expectedInitialSharesAuthorized
+        ) = createInitialDummyStockClassData();
+        capTable.createStockClass(expectedId, expectedClassType, expectedPricePerShare, expectedInitialSharesAuthorized);
+        (bytes16 actualId, string memory actualClassType, uint256 actualPricePerShare, uint256 actualInitialSharesAuthorized) = capTable
+            .getStockClassById(expectedId);
+        assertEq(actualId, expectedId);
+        assertEq(actualClassType, expectedClassType);
+        assertEq(actualPricePerShare, expectedPricePerShare);
+        assertEq(actualInitialSharesAuthorized, expectedInitialSharesAuthorized);
+    }
 }

--- a/src/scripts/deployAndLinkLibs.js
+++ b/src/scripts/deployAndLinkLibs.js
@@ -82,7 +82,7 @@ async function deployLib(lib, libs) {
             "--private-key",
             privateKey,
             `${lib.path}:${lib.libraryName || lib.fileName}`,
-            "--via-ir",
+            // "--via-ir",
             "--json",
             ...librariesDepsArgs,
         ];


### PR DESCRIPTION
## What?

Follow up to this PR: https://github.com/poet-network/tap-cap-table/pull/76

Fix build error related to importing the CapTable (e.g. instantiating a CapTable in tests). Use structs for functions with many params until builds complete without having to use the --via-ir flag.

## Why?

Functions with more than ~6 params were causing us to have to build with Yul IR pipeline. This results in slower build times but also failed builds when trying to import the CapTable.sol contract even with --via-ir.



## Screenshots (optional)

