### PR TITLE
(Housekeeping): Reflect W2 Backend based on W3 changes 

### DIFF
--- a/src/chain-operations/transactionHandlers.js
+++ b/src/chain-operations/transactionHandlers.js
@@ -30,45 +30,45 @@ export const handleStockIssuance = async (stock, issuerId, timestamp) => {
 
     // TODO: (Victor): Think about data validation if the transaction is created onchain, without going through the API
     const sharePriceOCF = {
-        amount: toDecimal(stock.share_price).toString(),
+        amount: toDecimal(stock.params.share_price).toString(),
         currency: "USD",
     };
 
     // Type represention of an ISO-8601 date, e.g. 2022-01-28.
     // TODO: I think if we want to back date historial transactions we will need an option to either pass date or create new one from block
     const dateOCF = new Date(timestamp * 1000).toISOString().split("T")[0];
-    const costBasisOCF = { amount: toDecimal(stock.cost_basis).toString(), currency: "USD" };
+    const costBasisOCF = { amount: toDecimal(stock.params.cost_basis).toString(), currency: "USD" };
     const share_numbers_issuedOCF = [
         {
-            starting_share_number: toDecimal(stock.share_numbers_issued.starting_share_number).toString(),
-            ending_share_number: toDecimal(stock.share_numbers_issued.ending_share_number).toString(),
+            starting_share_number: toDecimal(stock.params.share_numbers_issued.starting_share_number).toString(),
+            ending_share_number: toDecimal(stock.params.share_numbers_issued.ending_share_number).toString(),
         },
     ];
 
-    const stakeholder = await readStakeholderById(convertBytes16ToUUID(stock.stakeholder_id));
+    const stakeholder = await readStakeholderById(convertBytes16ToUUID(stock.params.stakeholder_id));
 
     const id = convertBytes16ToUUID(stock.id);
     const createdStockIssuance = await upsertStockIssuanceById(id, {
         _id: id,
         object_type: stock.object_type,
-        stock_class_id: convertBytes16ToUUID(stock.stock_class_id),
-        stock_plan_id: convertBytes16ToUUID(stock.stock_plan_id),
+        stock_class_id: convertBytes16ToUUID(stock.params.stock_class_id),
+        stock_plan_id: convertBytes16ToUUID(stock.params.stock_plan_id),
         share_numbers_issued: share_numbers_issuedOCF,
         share_price: sharePriceOCF,
-        quantity: toDecimal(stock.quantity).toString(),
-        vesting_terms_id: convertBytes16ToUUID(stock.vesting_terms_id),
+        quantity: toDecimal(stock.params.quantity).toString(),
+        vesting_terms_id: convertBytes16ToUUID(stock.params.vesting_terms_id),
         cost_basis: costBasisOCF,
-        stock_legend_ids: convertBytes16ToUUID(stock.stock_legend_ids),
+        stock_legend_ids: convertBytes16ToUUID(stock.params.stock_legend_ids),
         issuance_type: stock.issuance_type,
         comments: stock.comments,
         security_id: convertBytes16ToUUID(stock.security_id),
         date: dateOCF,
-        custom_id: convertBytes16ToUUID(stock.custom_id), //TODO: is this uuid or custom id?
+        custom_id: convertBytes16ToUUID(stock.params.custom_id), //TODO: is this uuid or custom id?
         stakeholder_id: stakeholder._id,
-        board_approval_date: stock.board_approval_date,
-        stockholder_approval_date: stock.stockholder_approval_date,
-        consideration_text: stock.consideration_text,
-        security_law_exemptions: stock.security_law_exemptions,
+        board_approval_date: stock.params.board_approval_date,
+        stockholder_approval_date: stock.params.stockholder_approval_date,
+        consideration_text: stock.params.consideration_text,
+        security_law_exemptions: stock.params.security_law_exemptions,
         // TAP Native Fields
         issuer: issuerId,
         is_onchain_synced: true,

--- a/src/controllers/transactions/cancellationController.js
+++ b/src/controllers/transactions/cancellationController.js
@@ -5,12 +5,15 @@ export const convertAndCreateCancellationStockOnchain = async (
     contract,
     { stakeholderId, stockClassId, quantity, security_id, reason_text, comments = [] }
 ) => {
-    const secIdBytes16 = convertUUIDToBytes16(security_id);
-    const stakeHolderIdBytes16 = convertUUIDToBytes16(stakeholderId);
-    const stockClassIdBytes16 = convertUUIDToBytes16(stockClassId);
-    const quantityScaled = toScaledBigNumber(quantity);
 
-    const tx = await contract.cancelStock(stakeHolderIdBytes16, stockClassIdBytes16, secIdBytes16, comments, reason_text, quantityScaled);
+    const tx = await contract.cancelStock({
+        stakeholder_id: convertUUIDToBytes16(stakeholderId),
+        stock_class_id: convertUUIDToBytes16(stockClassId),
+        security_id: convertUUIDToBytes16(security_id),
+        comments, reason_text,
+        quantity: toScaledBigNumber(quantity),
+        nonce: 0
+    });
     await tx.wait();
 
     console.log(`✅ | Cancellation Completed: quantity affected: ${quantity}`);

--- a/src/controllers/transactions/issuanceController.js
+++ b/src/controllers/transactions/issuanceController.js
@@ -24,7 +24,7 @@ const checkIssuanceValues = (issuance) => {
 
 export const convertAndCreateIssuanceStockOnchain = async (contract, issuance) => {
     const checkedValues = checkIssuanceValues(issuance);
-    const {
+    let {
         stakeholder_id,
         stock_class_id,
         quantity,
@@ -44,38 +44,39 @@ export const convertAndCreateIssuanceStockOnchain = async (contract, issuance) =
     } = checkedValues;
 
     // First: convert OCF Types to Onchain Types
-    const stakeholderIdBytes16 = convertUUIDToBytes16(stakeholder_id);
-    const stockClassIdBytes16 = convertUUIDToBytes16(stock_class_id);
-    const vestingTermsBytes16 = convertUUIDToBytes16(vesting_terms_id);
-    const stockPlanIdBytes16 = convertUUIDToBytes16(stock_plan_id);
-    const quantityScaled = toScaledBigNumber(quantity);
-    const sharePriceScaled = toScaledBigNumber(share_price.amount);
+    stakeholder_id = convertUUIDToBytes16(stakeholder_id);
+    stock_class_id = convertUUIDToBytes16(stock_class_id);
+    vesting_terms_id = convertUUIDToBytes16(vesting_terms_id);
+    stock_plan_id = convertUUIDToBytes16(stock_plan_id);
+    quantity = toScaledBigNumber(quantity);
+    share_price = toScaledBigNumber(share_price.amount);
 
     let StockLegendIdsBytes16 = [];
     for (const legendId of stock_legend_ids) {
         const legendIdBytes16 = convertUUIDToBytes16(legendId);
         StockLegendIdsBytes16.push(legendIdBytes16);
     }
+    console.log({stakeholder_id})
 
     // Second: create issuance onchain
-    const tx = await contract.issueStockByTA(
-        stockClassIdBytes16,
-        stockPlanIdBytes16,
+    const tx = await contract.issueStockByTA({
+        stock_class_id,
+        stock_plan_id,
         share_numbers_issued, // not converted
-        sharePriceScaled,
-        quantityScaled,
-        vestingTermsBytes16,
+        share_price,
+        quantity,
+        vesting_terms_id,
         cost_basis, // not converted
-        StockLegendIdsBytes16,
+        stock_legend_ids,
         issuance_type,
         comments,
         custom_id,
-        stakeholderIdBytes16,
+        stakeholder_id,
         board_approval_date,
         stockholder_approval_date,
         consideration_text,
         security_law_exemptions
-    );
+    });
     await tx.wait();
     console.log("✅ | Issued stock onchain, unconfirmed: ", issuance);
 };

--- a/src/controllers/transactions/reissuanceController.js
+++ b/src/controllers/transactions/reissuanceController.js
@@ -9,7 +9,7 @@ export const convertAndCreateReissuanceStockOnchain = async (
         reason_text,
         comments = [] }
 ) => {
-    const resulting_security_ids_b16 = resulting_security_ids.map(sId => convertUUIDToBytes16(sId)),
+    const resulting_security_ids_b16 = resulting_security_ids.map(sId => convertUUIDToBytes16(sId))
     const tx = await contract.reissueStock({
         stakeholder_id: convertUUIDToBytes16(stakeholderId),
         stock_class_id: convertUUIDToBytes16(stockClassId),

--- a/src/controllers/transactions/reissuanceController.js
+++ b/src/controllers/transactions/reissuanceController.js
@@ -9,11 +9,13 @@ export const convertAndCreateReissuanceStockOnchain = async (
         reason_text,
         comments = [] }
 ) => {
-    const secIdBytes16 = convertUUIDToBytes16(security_id);
-    const stakeHolderIdBytes16 = convertUUIDToBytes16(stakeholderId);
-    const stockClassIdBytes16 = convertUUIDToBytes16(stockClassId);
-    const resultingSecIds  = resulting_security_ids.map( sId => convertUUIDToBytes16(sId))
-
-    const tx = await contract.reissueStock(stakeHolderIdBytes16, stockClassIdBytes16, resultingSecIds, secIdBytes16, comments, reason_text);
+    const resulting_security_ids_b16 = resulting_security_ids.map(sId => convertUUIDToBytes16(sId)),
+    const tx = await contract.reissueStock({
+        stakeholder_id: convertUUIDToBytes16(stakeholderId),
+        stock_class_id: convertUUIDToBytes16(stockClassId),
+        security_id: convertUUIDToBytes16(security_id),
+        comments,
+        reason_text
+    }, resulting_security_ids_b16);
     await tx.wait();
 };

--- a/src/controllers/transactions/repurchaseController.js
+++ b/src/controllers/transactions/repurchaseController.js
@@ -6,25 +6,22 @@ export const convertAndCreateRepurchaseStockOnchain = async (
     { stakeholderId,
         stockClassId,
         security_id,
-        considertationText= "",
+        considertationText = "",
         quantity,
         price,
         comments = [] }
 ) => {
-    const secIdBytes16 = convertUUIDToBytes16(security_id);
-    const stakeHolderIdBytes16 = convertUUIDToBytes16(stakeholderId);
-    const stockClassIdBytes16 = convertUUIDToBytes16(stockClassId);
-    const scaledQuantity = toScaledBigNumber(quantity)
-    const scaledPrice =  toScaledBigNumber(price.amount)
+    const scaledPrice = toScaledBigNumber(price.amount)
 
-    const tx = await contract.repurchaseStock(
-        stakeHolderIdBytes16,
-        stockClassIdBytes16,
-        secIdBytes16,
+    const tx = await contract.repurchaseStock({
+        stakeholder_id: convertUUIDToBytes16(stakeholderId),
+        stock_class_id: convertUUIDToBytes16(stockClassId),
+        security_id: convertUUIDToBytes16(security_id),
+        quantity: toScaledBigNumber(quantity),
         comments,
-        considertationText,
-        scaledQuantity,
-        scaledPrice
-    );
+        nonce: 0, // needed because of StockParamsQuantity Struct
+        reason_text: considertationText // there is no consideration text in StockParamsQuantity Struct
+        // consideration_text: considertationText
+    }, scaledPrice);
     await tx.wait();
 };

--- a/src/controllers/transactions/retractionController.js
+++ b/src/controllers/transactions/retractionController.js
@@ -8,10 +8,13 @@ export const convertAndCreateRetractionStockOnchain = async (
         reason_text,
         comments = [] }
 ) => {
-    const secIdBytes16 = convertUUIDToBytes16(security_id);
-    const stakeHolderIdBytes16 = convertUUIDToBytes16(stakeholderId);
-    const stockClassIdBytes16 = convertUUIDToBytes16(stockClassId);
 
-    const tx = await contract.retractStockIssuance(stakeHolderIdBytes16, stockClassIdBytes16, secIdBytes16, comments, reason_text);
+    const tx = await contract.retractStockIssuance({
+        stakeholder_id: convertUUIDToBytes16(stakeholderId),
+        stock_class_id: convertUUIDToBytes16(stockClassId),
+        security_id: convertUUIDToBytes16(security_id),
+        comments,
+        reason_text
+    });
     await tx.wait();
 };

--- a/src/db/objects/Issuer.js
+++ b/src/db/objects/Issuer.js
@@ -18,7 +18,7 @@ const IssuerSchema = new mongoose.Schema({
     comments: [String],
     deployed_to: String,
     is_manifest_created: { type: Boolean, default: false },
-});
+}, { timestamps: true });
 
 const Issuer = mongoose.model("Issuer", IssuerSchema);
 

--- a/src/db/objects/Stakeholder.js
+++ b/src/db/objects/Stakeholder.js
@@ -16,7 +16,7 @@ const StakeholderSchema = new mongoose.Schema({
         ref: "Issuer",
     },
     is_onchain_synced: { type: Boolean, default: false },
-});
+}, { timestamps: true });
 
 const Stakeholder = mongoose.model("Stakeholder", StakeholderSchema);
 

--- a/src/db/objects/StockClass.js
+++ b/src/db/objects/StockClass.js
@@ -23,7 +23,7 @@ const StockClassSchema = new mongoose.Schema({
         ref: "Issuer",
     },
     is_onchain_synced: { type: Boolean, default: false },
-});
+}, {timestamps: true});
 
 const Stockclass = mongoose.model("StockClass", StockClassSchema);
 

--- a/src/db/objects/transactions/issuance/StockIssuance.js
+++ b/src/db/objects/transactions/issuance/StockIssuance.js
@@ -27,7 +27,7 @@ const StockIssuanceSchema = new mongoose.Schema({
         ref: "Issuer",
     },
     is_onchain_synced: { type: Boolean, default: false },
-});
+}, {timestamps: true});
 
 const StockIssuance = mongoose.model("StockIssuance", StockIssuanceSchema);
 

--- a/src/scripts/testAcceptance.js
+++ b/src/scripts/testAcceptance.js
@@ -7,7 +7,7 @@ connectDB();
 const main = async () => {
     console.log("⏳ | Creating stock acceptance…");
 
-    const lastStockIssuance = await StockIssuance.find().sort({ _id: -1 }).limit(1);
+    const lastStockIssuance = await StockIssuance.find().sort({ updatedAt: -1 }).limit(1);
     const { issuer, security_id, stakeholder_id, stock_class_id, quantity } = lastStockIssuance[0];
     console.log({ issuer, security_id, stakeholder_id, stock_class_id, quantity });
 

--- a/src/scripts/testAdjustment.js
+++ b/src/scripts/testAdjustment.js
@@ -5,7 +5,7 @@ import connectDB from "../db/config/mongoose.js";
 connectDB();
 
 const main = async () => {
-    const lastStockIssuance = await StockIssuance.find().sort({ _id: -1 }).limit(1);
+    const lastStockIssuance = await StockIssuance.find().sort({ updatedAt: -1 }).limit(1);
     const { issuer, security_id, stakeholder_id, stock_class_id, quantity } = lastStockIssuance[0];
     const stockClassAdjResponse = await axios.post(
         "http://localhost:8080/transactions/adjust/stock-class/authorized-shares",

--- a/src/scripts/testCancellation.js
+++ b/src/scripts/testCancellation.js
@@ -5,8 +5,9 @@ import connectDB from "../db/config/mongoose.js";
 connectDB();
 
 const main = async () => {
-    const lastStockIssuance = await StockIssuance.find().sort({ _id: -1 }).limit(1);
-    console.log("lastStockIssuance", lastStockIssuance[0]);
+    const lastStockIssuance = await StockIssuance.find().sort({ updatedAt: -1 }).limit(1);
+    if (!lastStockIssuance || !lastStockIssuance.length) throw Error("No Issuance Exist")
+
     const { issuer, security_id, stakeholder_id, stock_class_id, quantity } = lastStockIssuance[0];
 
     console.log({ issuer, security_id, stakeholder_id, stock_class_id, quantity });

--- a/src/scripts/testIssuance.js
+++ b/src/scripts/testIssuance.js
@@ -9,20 +9,20 @@ connectDB();
 const main = async () => {
     console.log("⏳ | Creating stock issuance");
 
-    const lastIssuer = await Issuer.find().sort({ _id: -1 }).limit(1); // finds the latest issuer
+    const lastIssuer = await Issuer.find().sort({ updatedAt: -1 }).limit(1); // finds the latest issuer
     const { _id: issuerId } = lastIssuer[0];
 
-    const lastStakeholder = await Stakeholder.find().sort({ _id: -1 }).limit(1);
+    const lastStakeholder = await Stakeholder.find().sort({ updatedAt: -1 }).limit(1);
     const { _id: stakeholderId } = lastStakeholder[0];
 
-    const lastStockClass = await StockClass.find().sort({ _id: -1 }).limit(1);
+    const lastStockClass = await StockClass.find().sort({ updatedAt: -1 }).limit(1);
     const { _id: stockClassId } = lastStockClass[0];
     console.log({ issuerId, stakeholderId, stockClassId });
 
     // create stockIssuance
     const stockIssuanceResponse = await axios.post(
         "http://localhost:8080/transactions/issuance/stock",
-        stockIssuance(issuerId, stakeholderId, stockClassId, "2000", "1.2")
+        stockIssuance(issuerId, stakeholderId, stockClassId, "500", "1.2")
     );
 
     console.log("✅ | stockIssuanceResponse1", stockIssuanceResponse.data);

--- a/src/scripts/testReissuance.js
+++ b/src/scripts/testReissuance.js
@@ -5,7 +5,7 @@ import connectDB from "../db/config/mongoose.js";
 connectDB();
 
 const main = async () => {
-    const lastStockIssuance = await StockIssuance.find().sort({ _id: -1 }).limit(1);
+    const lastStockIssuance = await StockIssuance.find().sort({ updatedAt: -1 }).limit(1);
     console.log("lastStockIssuance", lastStockIssuance[0]);
     const { issuer, security_id, stakeholder_id, stock_class_id, quantity } = lastStockIssuance[0];
 

--- a/src/scripts/testRepurchase.js
+++ b/src/scripts/testRepurchase.js
@@ -7,7 +7,7 @@ connectDB();
 const main = async () => {
     console.log("⏳ | Creating stock repurchase");
 
-    const lastStockIssuance = await StockIssuance.find().sort({ _id: -1 }).limit(1);
+    const lastStockIssuance = await StockIssuance.find().sort({ updatedAt: -1 }).limit(1);
     console.log("lastStockIssuance", lastStockIssuance[0]);
     const { issuer, security_id, stakeholder_id, stock_class_id, quantity } = lastStockIssuance[0];
 
@@ -16,7 +16,7 @@ const main = async () => {
         stockRepurchase(
             issuer, // Issuer ID
             quantity,
-            "1.5",
+            "1.0",
             stakeholder_id, // Stakeholder ID
             stock_class_id, // StockClass ID
             security_id, // Security ID

--- a/src/scripts/testRetraction.js
+++ b/src/scripts/testRetraction.js
@@ -9,7 +9,7 @@ const main = async () => {
     console.log("⏳ | Creating stock retraction…");
 
     // latest StockIssuance record inserted
-    const lastStockIssuance = await StockIssuance.find().sort({ _id: -1 }).limit(1);
+    const lastStockIssuance = await StockIssuance.find().sort({ updatedAt: -1 }).limit(1);
     console.log("lastStockIssuance", lastStockIssuance[0]);
     const { issuer, security_id, stakeholder_id, stock_class_id } = lastStockIssuance[0];
 


### PR DESCRIPTION
## What?

- Modified arguments to contract to object based on the contract argument
- Modified the transaction listener to data access based on the property `params`
- Enabled timestamps in mongo `Issuer`, `Stakeholder`, `StockClass` and `StockIssuance` data objects
- Modified test scripts to pull the latest inserted record by `updatedBy` field


## Why?
- To maintain changes introduced by #77 


### Notes:
- `cancelStock` and `repurchaseStock` functions on the CapTable smart contract have a `params` argument of a type [StockParamsQuantity](https://github.com/poet-network/tap-cap-table/blob/dev/chain/src/lib/Structs.sol#L118-L118) which have a field `nonce`, the value is hardcoded from the backend.  Ultimately we want to change that in the future

