### PR TITLE
Misc Fixes and Test Coverage

### DIFF
--- a/chain/test/AccessControl.t.sol
+++ b/chain/test/AccessControl.t.sol
@@ -1,0 +1,65 @@
+// // SPDX-License-Identifier: MIT
+// pragma solidity ^0.8.20;
+
+// import "forge-std/Test.sol";
+// import "./CapTable.t.sol";
+
+// contract RolesTests is CapTableTest {
+//     address RANDO_ADDR = address(0xf001);
+//     address OPERATOR_ADDR = address(0xf002);
+
+//     function testOperatorRole() public {
+//         _attemptOperatorFunc(false, true);
+
+//         capTable.addOperator(RANDO_ADDR);
+//         _attemptOperatorFunc(true, true);
+
+//         capTable.removeOperator(RANDO_ADDR);
+//         _attemptOperatorFunc(false, true);
+//     }
+
+//     function testAdminRole() public {
+//         _attemptAdminFunc(false);
+
+//         capTable.addAdmin(RANDO_ADDR);
+//         _attemptAdminFunc(true);
+
+//         capTable.removeAdmin(RANDO_ADDR);
+//         _attemptAdminFunc(false);
+//     }
+
+//     function testAdminIsOperatorRole() public {
+//         _attemptOperatorFunc(true, false);
+//     }
+
+//     function _attemptOperatorFunc(bool shouldBeOperator, bool asRando) internal {
+//         if (shouldBeOperator) {
+//             vm.expectRevert("No transferor");
+//         } else {
+//             vm.expectRevert("Does not have operator role");
+//         }
+//         if (asRando) {
+//             vm.prank(RANDO_ADDR);
+//         }
+//         /// @dev this was chosen arbitrarily bc it is onlyOperator. The arguments are garbage and we expect it to throw
+//         capTable.transferStock(
+//             0x0000000000000000000000000000000a,
+//             0x0000000000000000000000000000000b,
+//             0x0000000000000000000000000000000c,
+//             false,
+//             0,
+//             0
+//         );
+//     }
+
+//     function _attemptAdminFunc(bool shouldBeAdmin) internal {
+//         if (shouldBeAdmin) {
+//             vm.expectRevert("Invalid wallet");
+//         } else {
+//             vm.expectRevert("Does not have admin role");
+//         }
+//         vm.prank(RANDO_ADDR);
+//         /// @dev this was chosen arbitrarily bc it is onlyAdmin. The arguments are garbage and we expect it to throw
+//         capTable.addWalletToStakeholder(0x0000000000000000000000000000000d, address(0));
+//     }
+// }

--- a/chain/test/StockRepurchase.t.sol
+++ b/chain/test/StockRepurchase.t.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/console.sol";
+
+import "./CapTable.t.sol";
+import {
+    StockIssuanceParams,
+    ShareNumbersIssued,
+    StockIssuance,
+    StockParams,
+    StockRepurchase
+} from "../src/lib/Structs.sol";
+
+contract StockRepurchaseTest is CapTableTest {
+    function _createStockClassAndStakeholder(uint256 stockClassInitialSharesAuthorized)
+        private
+        returns (bytes16, bytes16)
+    {
+        bytes16 stakeholderId = 0xd3373e0a4dd940000000000000000005;
+        capTable.createStakeholder(stakeholderId, "INDIVIDUAL", "EMOLOYEE");
+
+        bytes16 stockClassId = 0xd3373e0a4dd940000000000000000000;
+        capTable.createStockClass(stockClassId, "Common", 100, stockClassInitialSharesAuthorized);
+
+        return (stockClassId, stakeholderId);
+    }
+
+    function testPartialStockRepurchase() public {
+        // Create stock class and stakeholder
+        (bytes16 stockClassId, bytes16 stakeholderId) = _createStockClassAndStakeholder(1000000);
+
+        uint256 issuanceQuantity = 1000;
+        // Issue stock
+        StockIssuanceParams memory params = StockIssuanceParams({
+            stock_class_id: stockClassId,
+            stock_plan_id: 0x00000000000000000000000000000000,
+            share_numbers_issued: ShareNumbersIssued(0, 0),
+            share_price: 10000000000,
+            quantity: issuanceQuantity,
+            vesting_terms_id: 0x00000000000000000000000000000000,
+            cost_basis: 5000000000,
+            stock_legend_ids: new bytes16[](0),
+            issuance_type: "RSA",
+            comments: new string[](0),
+            custom_id: "R2-D2",
+            stakeholder_id: stakeholderId,
+            board_approval_date: "2023-01-01",
+            stockholder_approval_date: "2023-01-02",
+            consideration_text: "For services rendered",
+            security_law_exemptions: new string[](0)
+        });
+        capTable.issueStock(params);
+
+        // Assert last transaction is of type issuance with the remaining amount
+        bytes memory issuanceTx = capTable.transactions(capTable.getTransactionsCount() - 1);
+        StockIssuance memory issuance = abi.decode(issuanceTx, (StockIssuance));
+
+        // Repurchase part of the stock
+        uint256 partialRepurchaseQuantity = 500;
+        capTable.repurchaseStock(
+            StockParams({
+                stakeholder_id: stakeholderId,
+                stock_class_id: stockClassId,
+                security_id: issuance.security_id,
+                reason_text: "Partial repurchase",
+                comments: new string[](0)
+            }),
+            partialRepurchaseQuantity,
+            50 // Assuming a valid price
+        );
+
+        uint256 transactionsCount = capTable.getTransactionsCount();
+        bytes memory remainingIssuanceTx = capTable.transactions(transactionsCount - 2);
+        StockIssuance memory remainingIssuance = abi.decode(remainingIssuanceTx, (StockIssuance));
+
+        assertEq(remainingIssuance.params.quantity, issuanceQuantity - partialRepurchaseQuantity);
+
+        // Assert last transaction is of type repurchase
+        bytes memory lastTransaction = capTable.transactions(transactionsCount - 1);
+        StockRepurchase memory repurchase = abi.decode(lastTransaction, (StockRepurchase));
+        assertEq(repurchase.object_type, "TX_STOCK_REPURCHASE");
+    }
+
+    function testFullStockRepurchase() public {
+        (bytes16 stockClassId, bytes16 stakeholderId) = _createStockClassAndStakeholder(1000000);
+
+        uint256 fullRepurchaseQuantity = 1000;
+        StockIssuanceParams memory params = StockIssuanceParams({
+            stock_class_id: stockClassId,
+            stock_plan_id: 0x00000000000000000000000000000000,
+            share_numbers_issued: ShareNumbersIssued(0, 0),
+            share_price: 10000000000,
+            quantity: fullRepurchaseQuantity,
+            vesting_terms_id: 0x00000000000000000000000000000000,
+            cost_basis: 5000000000,
+            stock_legend_ids: new bytes16[](0),
+            issuance_type: "RSA",
+            comments: new string[](0),
+            custom_id: "R2-D2",
+            stakeholder_id: stakeholderId,
+            board_approval_date: "2023-01-01",
+            stockholder_approval_date: "2023-01-02",
+            consideration_text: "For services rendered",
+            security_law_exemptions: new string[](0)
+        });
+
+        capTable.issueStock(params);
+        // Assert last transaction is of type issuance with the remaining amount
+        uint256 issuanceTxIdx = capTable.getTransactionsCount() - 1;
+        bytes memory issuanceTx = capTable.transactions(issuanceTxIdx);
+        StockIssuance memory issuance = abi.decode(issuanceTx, (StockIssuance));
+        // Repurchase all of the stock
+        uint256 expectedNewPrice = 99;
+        capTable.repurchaseStock(
+            StockParams({
+                stakeholder_id: stakeholderId,
+                stock_class_id: stockClassId,
+                security_id: issuance.security_id,
+                reason_text: "Full repurchase",
+                comments: new string[](0)
+            }),
+            fullRepurchaseQuantity,
+            expectedNewPrice
+        );
+
+        uint256 transactionsCount = capTable.getTransactionsCount();
+        uint256 remainingIssuaneTxIndex = transactionsCount - 2;
+        bytes memory remainingIssuanceTx = capTable.transactions(remainingIssuaneTxIndex);
+        StockIssuance memory repuchaseIssuance = abi.decode(remainingIssuanceTx, (StockIssuance));
+
+        assertEq(repuchaseIssuance.params.quantity, fullRepurchaseQuantity);
+
+        uint256 lastTransactionIndex = transactionsCount - 1;
+        bytes memory lastTransaction = capTable.transactions(lastTransactionIndex);
+        StockRepurchase memory repurchase = abi.decode(lastTransaction, (StockRepurchase));
+
+        assertEq(repurchase.object_type, "TX_STOCK_REPURCHASE");
+        assertEq(repurchase.price, expectedNewPrice);
+    }
+}


### PR DESCRIPTION
## What?

### 1. Added Unit tests for the following:
  - [x] Stock Issuance
  - [x] Stock Transfer
  - [x] Stock Cancellation
  - [x] Stock Repurchase
  - [x] Stock Retraction
  - [x] Stock Reissuance
  - [x] Stock Adjustment
  - [x] Stock Acceptance
  - [x] Seeding
 
### 2. Fixed bugs that found while testing
  - Fix 0 quantity bug in a `transferStock`
  - Invoke the right issue stock function name on the CapTable smart contract from W2
### 3. Added  the following public functions to `CapTable` smart contract 
  - `getTransactionsCount`: gets the total transactions count
  - `getTotalActiveSecuritiesCount`:  gets the total active securities count in the cap table
### 4. General Improvement
  - Add a timestamp to StockTransfer Mongo record upon insertion

## Why?
Increase code coverage

## Test Coverage - 76.19%
Here are all the external functions in the cap table, ✅ means it's covered:
- seedMultipleActivePositionsAndSecurityIds ✅
- seedSharesAuthorizedAndIssued ✅
- createStakeholder ✅
- addWalletToStakeholder
- removeWalletFromStakeholder
- getStakeholderIdByWallet
- acceptStock ✅
- adjustIssuerAuthorizedShares ✅
- adjustStockClassAuthorizedShares ✅
- createStockClass ✅
- createStockLegendTemplate
- getStakeholderById ✅
- getStockClassById ✅
- getTotalNumberOfStakeholders ✅
- getTotalNumberOfStockClasses ✅
- getTransactionsCount ✅
- issueStock ✅
- repurchaseStock ✅
- retractStockIssuance ✅
- reissueStock✅
- cancelStock ✅
- transferStock ✅ 


## Screenshots
<img width="562" alt="image" src="https://github.com/poet-network/tap-cap-table/assets/55929982/98c66046-3d6f-4421-9d96-1f1165e529a0">