### PR TITLE
chore(config): update chain to plume run tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,19 +2,21 @@
 DATABASE_URL="mongodb://tap:tap@localhost:27017/mongo?authSource=admin&retryWrites=true&w=majority"
 DATABASE_REPLSET="0"  # set to "1" if using --replSet option in mongo. this allows transactions
 
-# RPC url for testnet (defaults to Anvil's http://127.0.0.1:8545)
+# RPC URL for blockchain connection
+# Anvil (local):        http://127.0.0.1:8545
+# Plume Mainnet:        https://rpc.plume.org
+# Plume Testnet:        https://testnet-rpc.plume.org
 RPC_URL=http://127.0.0.1:8545
 
-# Change this to the chain id of the network you are deploying to
-# Use 31337 for Anvil's, 32586980208 for Arbitrum's
+# Chain ID for the network you are deploying to
+# Anvil (local):        31337
+# Plume Mainnet:        98866
+# Plume Testnet:        98867
 CHAIN_ID=31337
 
 # Update with the private key of the account that will be used to deploy the contracts
+# Using Anvil's first default account in development
 PRIVATE_KEY=UPDATE_ME
-
-# Etherscan API keys
-ETHERSCAN_L2_API_KEY=UPDATE_ME
-ETHERSCAN_L1_API_KEY=UPDATE_ME
 
 # Server port
 PORT=8293

--- a/WARP.md
+++ b/WARP.md
@@ -274,7 +274,7 @@ The system supports multiple environments via `.env` files:
 - `DATABASE_URL`: MongoDB connection string
 - `DATABASE_REPLSET`: Set to "1" for replica set (enables transactions)
 - `RPC_URL`: Ethereum RPC endpoint
-- `CHAIN_ID`: Network chain ID (31337 for Anvil, 32586980208 for Arbitrum)
+- `CHAIN_ID`: Network chain ID (31337 for Anvil, 98866 for Plume Mainnet, 98867 for Plume Testnet)
 - `PRIVATE_KEY`: Deployer private key
 - `PORT`: API server port (default 8293)
 

--- a/chain/foundry.toml
+++ b/chain/foundry.toml
@@ -8,14 +8,16 @@ cbor_metadata = false
 via_ir = true
 optimizer = true
 optimizer_runs = 200
+evm_version = 'cancun'
 
 
 [rpc_endpoints]
 rpc_url = "${RPC_URL}"
+plume_mainnet = "https://rpc.plume.org"
+plume_testnet = "https://testnet-rpc.plume.org"
 
 [etherscan]
-optimism_goerli_etherscan = { key = "${ETHERSCAN_L2_API_KEY}", chain = "goerli" }
-
-
+plume_mainnet = { key = "", chain = 98866, url = "https://explorer.plume.org/api/" }
+plume_testnet = { key = "", chain = 98867, url = "https://testnet-explorer.plume.org/api/" }
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/docs/src/pages/development/_meta.json
+++ b/docs/src/pages/development/_meta.json
@@ -1,6 +1,8 @@
 {
     "install": "Install",
     "setup": "Setup",
+    "run-server": "Run Server",
     "factory-deploy": "Deploy Factory",
     "cap-table-deploy": "Deploy Cap Table"
 }
+

--- a/docs/src/pages/development/cap-table-deploy.mdx
+++ b/docs/src/pages/development/cap-table-deploy.mdx
@@ -1,27 +1,14 @@
-import { Steps } from 'nextra/components';
+import { Steps, Callout } from 'nextra/components';
 
-# Cap table smart contract
+# Deploy a Cap Table
 
-The cap table smart contract is responsible for minting the inital cap table onchain can be found in our repo under [CapTable.sol](https://github.com/transfer-agent-protocol/tap-cap-table/blob/main/chain/src/CapTable.sol).
+With the server running, you can create your first cap table via the API. This deploys a new cap table contract through the factory and creates an issuer record.
 
-## Deploy cap table smart contract
 <Steps>
 
-### Run the server
+### Create an issuer via POST request
 
-In the root folder, run the development server:
-
-```bash
-pnpm dev
-```
-
-### Open Postman, and create a new POST request
-
-Create a new request in Postman, and set the request type to `POST`. In the URL field, enter `http://localhost:{{PORT}}/issuer/create` - your port should be `8293` if you haven't changed it.
-
-### Set the request body
-
-In the request body, use this example JSON. You can change anything you like here. Every field is required and will first run through validation against the OCF schema using our [validateInputAgainstSchema](https://github.com/transfer-agent-protocol/tap-cap-table/blob/main/src/utils/validateInputAgainstSchema.js) script.
+Using Postman or curl, send a POST request to `http://localhost:8293/issuer/create`:
 
 ```json
 {
@@ -52,8 +39,23 @@ In the request body, use this example JSON. You can change anything you like her
 }
 ```
 
-### Send the request
+All fields are validated against the [OCF schema](https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF).
 
-Your request should look like this. Notice that in the response, you get the `capTableAddress` which is the address of the cap table smart contract. Congratulations, you've deployed your first cap table smart contract!
-![Factories](../../../public/images/cap-table-issuer.png)
+### Check the response
+
+The response includes the `capTableAddress` - this is your new cap table contract deployed on-chain:
+
+![Cap Table Issuer Response](../../../public/images/cap-table-issuer.png)
+
 </Steps>
+
+<Callout type="success">
+Congratulations! You've deployed your first cap table smart contract.
+</Callout>
+
+## What's next?
+
+With your cap table deployed, you can:
+- Create stakeholders via `POST /stakeholder/create`
+- Create stock classes via `POST /stock-class/create`
+- Issue stock via `POST /transactions/stock/issuance`

--- a/docs/src/pages/development/factory-deploy.mdx
+++ b/docs/src/pages/development/factory-deploy.mdx
@@ -1,55 +1,54 @@
-import { Steps } from 'nextra/components';
+import { Steps, Callout } from 'nextra/components';
 import Image from 'next/image';
 
-# Factory smart contract
+# Deploy the Factory Contract
 
-We use a factory pattern that's responsible for creating new cap tables and managing the cap table addresses. You can find the smart contract in our repo under [capTableFactory.sol](https://github.com/transfer-agent-protocol/tap-cap-table/blob/main/chain/src/CapTableFactory.sol).
+The factory contract deploys new cap tables and manages their addresses. It uses a beacon proxy pattern so all cap tables can be upgraded together.
 
-## Deploy the contract
 <Steps>
 
-### Run the script to deploy the contract
+### Run the deployment script
 
-With Anvil running, run our script:
+With Anvil running in another terminal:
 
 ```bash
 pnpm run deploy-factory
 ```
 
-### Check the contract address in Anvil
+### Note the contract addresses
 
-In your terminal, you should get the contract address after the script runs. You can also check the contract address in Anvil.
+The script outputs two addresses you'll need:
 
 ```bash
-./scripts/deployFactory.sh
-+ cd chain
-+ forge script script/CapTableFactory.s.sol --broadcast --fork-url http://127.0.0.1:8545
-[⠊] Compiling...No files changed, compilation skipped
-[⠒] Compiling...
-Script ran successfully.
-
 == Logs ==
   Upgrading CapTableFactory with CapTable implementation
   Deploying CapTableFactory and CapTable implementation
-  CapTable implementation deployed at: 0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82
-  CapTableFactory deployed at: 0x9A676e781A523b5d0C0e43731313A708CB607508
+  CapTable implementation deployed at: 0x5FbDB2315678afecb367f032d93F642f64180aa3
+  CapTableFactory deployed at: 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
 ```
-### Manually add CapTableFactory to MongoDB
 
-For this, you'll need to use Mongo Compass that you installed earlier. You can find the connection string in the `.env` file.
+### Add factory to MongoDB
 
-Under databases collection, search for `factories` and add the contract address to the collection using add data -> insert document.
+Open MongoDB Compass and connect using:
+```
+mongodb://tap:tap@localhost:27017
+```
+
+Navigate to the `mongo` database, find (or create) the `factories` collection, and insert a new document:
 
 ```json
 {
-	"implementation_address": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
-  	"factory_address": "0x9A676e781A523b5d0C0e43731313A708CB607508"
+  "implementation_address": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+  "factory_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
 }
- ```
+```
 
-Keep in mind that your contract address will be different from the one in the example.
+<Callout type="info">
+Use the addresses from your deployment output - they'll be different each time.
+</Callout>
 
 ![Factories](../../../public/images/mongo-factories.png)
+
 </Steps>
 
-With this done, you're ready to deploy the first cap table using the factory contract. 
+Next, [start the server](/development/run-server) to begin using the API.

--- a/docs/src/pages/development/run-server.mdx
+++ b/docs/src/pages/development/run-server.mdx
@@ -1,0 +1,43 @@
+import { Steps, Callout, Tabs } from 'nextra/components';
+
+# Run the Server
+
+The Node.js server provides the REST API for managing cap tables. It connects to MongoDB for storage and to the blockchain for on-chain operations.
+
+## Development mode
+
+<Steps>
+
+### Start the server
+
+```bash
+pnpm dev
+```
+
+This runs the server with hot-reloading and the **event poller** enabled.
+
+### Verify it's running
+
+```bash
+curl http://localhost:8293/
+```
+
+You should see a response confirming the server is up.
+
+</Steps>
+
+## What is the event poller?
+
+The event poller watches the blockchain for contract events (like stock issuances, transfers, etc.) and syncs them to MongoDB. This keeps your off-chain database in sync with on-chain state.
+
+- **`pnpm dev`** - Server with event poller (recommended for development)
+- **`pnpm prod`** - Server without event poller
+- **`pnpm prod-poller`** - Standalone event poller only (for production, processes finalized blocks)
+
+<Callout type="info">
+For local development, use `pnpm dev` which includes the poller. In production, you'd typically run the server and poller as separate processes.
+</Callout>
+
+## Next steps
+
+With the server running, you can [deploy your first cap table](/development/cap-table-deploy) using the API.

--- a/docs/src/pages/development/setup.mdx
+++ b/docs/src/pages/development/setup.mdx
@@ -1,76 +1,71 @@
-import { Steps } from 'nextra/components';
+import { Steps, Callout } from 'nextra/components';
 
 # Initial setup
 
-Our `.env.example` files are setup for local development with Docker and Foundry. You'll need to copy them to a new `.env` and update the values with your own. You have to do this twice in the root of the project and inside of the `/chain` folder.
+This guide walks you through setting up your local development environment. You'll need three things running:
+1. **Docker** - for MongoDB
+2. **Anvil** - local blockchain
+3. **Server** - the Node.js API (covered in the next section)
 
-While developing, you'll run Anvil in one terminal window, and the server in another. You'll also need to run Docker in the root folder.
-
-## Setup the server in the root folder
+## Configure environment variables
 
 <Steps>
 
-### 1. Setup your environment
-
-Copy the `.env.example` to `.env` in the root folder
+### 1. Copy the example env file
 
 ```bash
-cd tap-cap-table && cp .env.example .env
-```
-
-You'll also need to setup your `.env.test.local` file for testing. This will be used by the test suite to run tests. 
-
-```bash
-cp .env .env.test.local
+cp .env.example .env
 ```
 
 ### 2. Update the values
 
-We provide initial defaults for connecting to the database and running Docker. You can get your `PRIVATE_KEY` values from Anvil in a second. You can also use your own (be careful not to use your mainnet keys!)
+The defaults work for local development. You'll get your `PRIVATE_KEY` from Anvil in the next section.
 
 ````md filename=".env"
-# Offchain db connection string for mongodb
+# MongoDB connection
 DATABASE_URL="mongodb://tap:tap@localhost:27017/mongo?authSource=admin&retryWrites=true&w=majority"
-DATABASE_OVERRIDE=""  # use a database other than the default in DATABASE_URL
-DATABASE_REPLSET="0"  # set to "1" if using --replSet option in mongo. this allows transactions
+DATABASE_REPLSET="0"  # set to "1" if using replica set
 
-# RPC url for testnet (defaults to Anvil's http://127.0.0.1:8545)
-RPC_URL=http://127.0.0.1:8545
+# Blockchain connection (Anvil local)
+RPC_URL=http://localhost:8545
+CHAIN_ID=31337
 
-# Change this to the chain id of the network you are deploying to
-# Use 31337 for Anvil's, 161221135 for Plume's
-CHAIN_ID=161221135
-
-# Update with the private key of the account that will be used to deploy the contracts
+# Deployer private key (get from Anvil output)
 PRIVATE_KEY=UPDATE_ME
-
-# Etherscan API keys
-ETHERSCAN_L2_API_KEY=UPDATE_ME
-ETHERSCAN_L1_API_KEY=UPDATE_ME
 
 # Server port
 PORT=8293
 ````
 
-### 3. Start Docker
-
-Start Docker in the root folder
-
-```bash
-docker compose up
-```
-
 </Steps>
 
-## Setup Anvil in the `/chain` folder
-
-This repo is onchain first. We use Anvil to run the local blockchain and deploy our cap table smart contracts there. At all times, you should have Anvil running alongside Docker and nodemon. With the mongo DB running on Docker you can start Anvil.
+## Start MongoDB with Docker
 
 <Steps>
 
-### 1. Setup Forge and Anvil in the `/chain` folder
+### 1. Start the container
 
-Install dependencies and setup Foundry and Forge with our setup script:
+```bash
+docker compose up -d
+```
+
+### 2. Verify MongoDB is running
+
+```bash
+docker ps
+```
+
+You should see `mongo:latest` running on port 27017.
+
+</Steps>
+
+## Start Anvil (local blockchain)
+
+Anvil is a local Ethereum node from Foundry. You'll run it in a separate terminal window.
+
+<Steps>
+
+### 1. Install dependencies and build contracts
 
 ```bash
 pnpm install && pnpm run setup
@@ -78,10 +73,22 @@ pnpm install && pnpm run setup
 
 ### 2. Start Anvil
 
-This will also give you the private key you need to update in your `.env` file.
-
 ```bash
 anvil
 ```
 
+### 3. Copy a private key
+
+Anvil outputs test accounts with private keys. Copy one and add it to your `.env` file:
+
+```
+PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+```
+
+<Callout type="warning">
+These are test keys only. Never use them on mainnet.
+</Callout>
+
 </Steps>
+
+With Docker and Anvil running, you're ready to [deploy the factory contract](/development/factory-deploy).

--- a/scripts/deployFactory.sh
+++ b/scripts/deployFactory.sh
@@ -1,15 +1,159 @@
 #!/bin/bash
+set -e
 
-# Accept a single argument of an env file to use. By default use .env at root
-USE_ENV_FILE=${1:-.env}
+# Usage: ./scripts/deployFactory.sh [env_file] [--verify]
+# Examples:
+#   ./scripts/deployFactory.sh                    # Deploy using .env
+#   ./scripts/deployFactory.sh --verify           # Deploy using .env with verification
+#   ./scripts/deployFactory.sh .env.prod          # Deploy using .env.prod
+#   ./scripts/deployFactory.sh .env.prod --verify # Deploy using .env.prod with verification
+#
+# This script deploys:
+#   1. DeleteContext library
+#   2. Adjustment library
+#   3. StockLib library
+#   4. CapTable implementation contract
+#   5. CapTableFactory (constructor takes CapTable address)
+#
+# After deployment, add the factory to MongoDB to use the API.
 
+# Parse arguments
+USE_ENV_FILE=".env"
+VERIFY=false
+
+for arg in "$@"; do
+    if [ "$arg" = "--verify" ]; then
+        VERIFY=true
+    elif [ -f "$arg" ]; then
+        USE_ENV_FILE="$arg"
+    fi
+done
+
+echo "📋 Loading environment from $USE_ENV_FILE"
 source $USE_ENV_FILE
 
-# Copy the root .env underneath chain so we dont have to maintain two copies
-TEMP=$PWD/chain/.env
-cp $USE_ENV_FILE $TEMP
-trap "rm $TEMP" EXIT
+# Validate required env vars
+if [ -z "$RPC_URL" ] || [ -z "$PRIVATE_KEY" ]; then
+    echo "❌ Error: RPC_URL and PRIVATE_KEY must be set in $USE_ENV_FILE"
+    exit 1
+fi
 
-set -x
+# Set up verification flags for Plume (Blockscout)
+VERIFY_FLAGS=""
+if [ "$VERIFY" = true ]; then
+    if [ "$CHAIN_ID" = "98866" ]; then
+        VERIFIER_URL="https://explorer.plume.org/api/"
+    elif [ "$CHAIN_ID" = "98867" ]; then
+        VERIFIER_URL="https://testnet-explorer.plume.org/api/"
+    else
+        echo "⚠️  Warning: Verification only supported for Plume (chain 98866/98867). Skipping verification."
+        VERIFY=false
+    fi
+    
+    if [ "$VERIFY" = true ]; then
+        VERIFY_FLAGS="--verify --verifier blockscout --verifier-url $VERIFIER_URL"
+        echo "✅ Verification enabled using Blockscout at $VERIFIER_URL"
+    fi
+fi
+
+# Common flags for forge create
+# --legacy is required for Plume and other non-EIP-1559 chains
+# ETH_RPC_URL is used because --rpc-url can be overridden by foundry.toml
+export ETH_RPC_URL="$RPC_URL"
+COMMON_FLAGS="--private-key $PRIVATE_KEY --broadcast --legacy $VERIFY_FLAGS"
+
 cd chain
-forge script script/CapTableFactory.s.sol:DeployCapTableFactoryDeployLocalScript --broadcast --fork-url $RPC_URL
+
+echo ""
+echo "🚀 Deploying CapTable + CapTableFactory"
+echo "   RPC: $RPC_URL"
+echo ""
+
+# Helper function to extract deployed address from forge create output
+extract_address() {
+    grep "Deployed to:" | awk '{print $3}'
+}
+
+# 1. Deploy DeleteContext library
+echo "📦 [1/5] Deploying DeleteContext library..."
+DELETE_CONTEXT_OUTPUT=$(forge create src/lib/DeleteContext.sol:DeleteContext $COMMON_FLAGS 2>&1)
+echo "$DELETE_CONTEXT_OUTPUT"
+DELETE_CONTEXT_ADDR=$(echo "$DELETE_CONTEXT_OUTPUT" | extract_address)
+if [ -z "$DELETE_CONTEXT_ADDR" ]; then
+    echo "❌ Failed to deploy DeleteContext"
+    exit 1
+fi
+echo "✅ DeleteContext deployed at: $DELETE_CONTEXT_ADDR"
+echo ""
+
+# 2. Deploy Adjustment library
+echo "📦 [2/5] Deploying Adjustment library..."
+ADJUSTMENT_OUTPUT=$(forge create src/lib/transactions/Adjustment.sol:Adjustment $COMMON_FLAGS 2>&1)
+echo "$ADJUSTMENT_OUTPUT"
+ADJUSTMENT_ADDR=$(echo "$ADJUSTMENT_OUTPUT" | extract_address)
+if [ -z "$ADJUSTMENT_ADDR" ]; then
+    echo "❌ Failed to deploy Adjustment"
+    exit 1
+fi
+echo "✅ Adjustment deployed at: $ADJUSTMENT_ADDR"
+echo ""
+
+# 3. Deploy StockLib library (links DeleteContext)
+echo "📦 [3/5] Deploying StockLib library..."
+STOCK_LIB_OUTPUT=$(forge create src/lib/Stock.sol:StockLib \
+    --libraries src/lib/DeleteContext.sol:DeleteContext:$DELETE_CONTEXT_ADDR \
+    $COMMON_FLAGS 2>&1)
+echo "$STOCK_LIB_OUTPUT"
+STOCK_LIB_ADDR=$(echo "$STOCK_LIB_OUTPUT" | extract_address)
+if [ -z "$STOCK_LIB_ADDR" ]; then
+    echo "❌ Failed to deploy StockLib"
+    exit 1
+fi
+echo "✅ StockLib deployed at: $STOCK_LIB_ADDR"
+echo ""
+
+# 4. Deploy CapTable implementation (links StockLib + Adjustment)
+echo "📦 [4/5] Deploying CapTable implementation..."
+CAP_TABLE_OUTPUT=$(forge create src/CapTable.sol:CapTable \
+    --libraries src/lib/Stock.sol:StockLib:$STOCK_LIB_ADDR \
+    --libraries src/lib/transactions/Adjustment.sol:Adjustment:$ADJUSTMENT_ADDR \
+    $COMMON_FLAGS 2>&1)
+echo "$CAP_TABLE_OUTPUT"
+CAP_TABLE_ADDR=$(echo "$CAP_TABLE_OUTPUT" | extract_address)
+if [ -z "$CAP_TABLE_ADDR" ]; then
+    echo "❌ Failed to deploy CapTable"
+    exit 1
+fi
+echo "✅ CapTable deployed at: $CAP_TABLE_ADDR"
+echo ""
+
+# 5. Deploy CapTableFactory (constructor takes CapTable address)
+# Note: Using --constructor-args-path because --constructor-args conflicts with --private-key in forge
+echo "📦 [5/5] Deploying CapTableFactory..."
+echo "$CAP_TABLE_ADDR" > /tmp/factory-constructor-args.txt
+FACTORY_OUTPUT=$(forge create src/CapTableFactory.sol:CapTableFactory \
+    --constructor-args-path /tmp/factory-constructor-args.txt \
+    $COMMON_FLAGS 2>&1)
+rm -f /tmp/factory-constructor-args.txt
+echo "$FACTORY_OUTPUT"
+FACTORY_ADDR=$(echo "$FACTORY_OUTPUT" | extract_address)
+if [ -z "$FACTORY_ADDR" ]; then
+    echo "❌ Failed to deploy CapTableFactory"
+    exit 1
+fi
+echo "✅ CapTableFactory deployed at: $FACTORY_ADDR"
+echo ""
+
+# Summary
+echo "========================================"
+echo "🎉 Deployment Complete!"
+echo "========================================"
+echo "CapTable (implementation): $CAP_TABLE_ADDR"
+echo "CapTableFactory:           $FACTORY_ADDR"
+echo "========================================"
+echo ""
+echo "Add to MongoDB factories collection:"
+echo "{"
+echo "  \"implementation_address\": \"$CAP_TABLE_ADDR\","
+echo "  \"factory_address\": \"$FACTORY_ADDR\""
+echo "}"

--- a/src/chain-operations/deployCapTable.js
+++ b/src/chain-operations/deployCapTable.js
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
-import CAP_TABLE from "../../chain/out/CapTable.sol/CapTable.json" assert { type: "json" };
-import CAP_TABLE_FACTORY from "../../chain/out/CapTableFactory.sol/CapTableFactory.json" assert { type: "json" };
+import CAP_TABLE from "../../chain/out/CapTable.sol/CapTable.json" with { type: "json" };
+import CAP_TABLE_FACTORY from "../../chain/out/CapTableFactory.sol/CapTableFactory.json" with { type: "json" };
 import { readfactories } from "../db/operations/read.js";
 import { toScaledBigNumber } from "../utils/convertToFixedPointDecimals.js";
 import { setupEnv } from "../utils/env.js";

--- a/src/chain-operations/getContractInstances.js
+++ b/src/chain-operations/getContractInstances.js
@@ -1,5 +1,5 @@
 import { ethers } from "ethers";
-import CAP_TABLE from "../../chain/out/CapTable.sol/CapTable.json" assert { type: "json" };
+import CAP_TABLE from "../../chain/out/CapTable.sol/CapTable.json" with { type: "json" };
 import { setupEnv } from "../utils/env.js";
 import getTXLibContracts from "../utils/getLibrariesContracts.js";
 import getProvider from "./getProvider.js";

--- a/src/db/scripts/seed.js
+++ b/src/db/scripts/seed.js
@@ -1,10 +1,10 @@
-import issuerSchema from "../../../ocf/schema/objects/Issuer.schema.json" assert { type: "json" };
-import stakeholderSchema from "../../../ocf/schema/objects/Stakeholder.schema.json" assert { type: "json" };
-import stockClassSchema from "../../../ocf/schema/objects/StockClass.schema.json" assert { type: "json" };
-import stockLegendTemplateSchema from "../../../ocf/schema/objects/StockLegendTemplate.schema.json" assert { type: "json" };
-import stockPlanSchema from "../../../ocf/schema/objects/StockPlan.schema.json" assert { type: "json" };
-import valuationSchema from "../../../ocf/schema/objects/Valuation.schema.json" assert { type: "json" };
-import vestingTermsSchema from "../../../ocf/schema/objects/VestingTerms.schema.json" assert { type: "json" };
+import issuerSchema from "../../../ocf/schema/objects/Issuer.schema.json" with { type: "json" };
+import stakeholderSchema from "../../../ocf/schema/objects/Stakeholder.schema.json" with { type: "json" };
+import stockClassSchema from "../../../ocf/schema/objects/StockClass.schema.json" with { type: "json" };
+import stockLegendTemplateSchema from "../../../ocf/schema/objects/StockLegendTemplate.schema.json" with { type: "json" };
+import stockPlanSchema from "../../../ocf/schema/objects/StockPlan.schema.json" with { type: "json" };
+import valuationSchema from "../../../ocf/schema/objects/Valuation.schema.json" with { type: "json" };
+import vestingTermsSchema from "../../../ocf/schema/objects/VestingTerms.schema.json" with { type: "json" };
 import {
     createIssuer,
     createStakeholder,
@@ -16,15 +16,15 @@ import {
 } from "../operations/create.js";
 import addTransactions from "../operations/transactions.js";
 
-import txStockIssuanceSchema from "../../../ocf/schema/objects/transactions/issuance/StockIssuance.schema.json" assert { type: "json" };
-import txStockCancellationSchema from "../../../ocf/schema/objects/transactions/cancellation/StockCancellation.schema.json" assert { type: "json" };
-import txStockTransferSchema from "../../../ocf/schema/objects/transactions/transfer/StockTransfer.schema.json" assert { type: "json" };
-import txStockRetractionSchema from "../../../ocf/schema/objects/transactions/retraction/StockRetraction.schema.json" assert { type: "json" };
-import txStockAcceptanceSchema from "../../../ocf/schema/objects/transactions/acceptance/StockAcceptance.schema.json" assert { type: "json" };
-import txStockReissuanceSchema from "../../../ocf/schema/objects/transactions/reissuance/StockReissuance.schema.json" assert { type: "json" };
-import txStockRepurchaseSchema from "../../../ocf/schema/objects/transactions/repurchase/StockRepurchase.schema.json" assert { type: "json" };
-import txStockClassAuthorizedSharesAdjustmentSchema from "../../../ocf/schema/objects/transactions/adjustment/StockClassAuthorizedSharesAdjustment.schema.json" assert { type: "json" };
-import txIssuerAuthorizedSharesAdjustmentSchema from "../../../ocf/schema/objects/transactions/adjustment/IssuerAuthorizedSharesAdjustment.schema.json" assert { type: "json" };
+import txStockIssuanceSchema from "../../../ocf/schema/objects/transactions/issuance/StockIssuance.schema.json" with { type: "json" };
+import txStockCancellationSchema from "../../../ocf/schema/objects/transactions/cancellation/StockCancellation.schema.json" with { type: "json" };
+import txStockTransferSchema from "../../../ocf/schema/objects/transactions/transfer/StockTransfer.schema.json" with { type: "json" };
+import txStockRetractionSchema from "../../../ocf/schema/objects/transactions/retraction/StockRetraction.schema.json" with { type: "json" };
+import txStockAcceptanceSchema from "../../../ocf/schema/objects/transactions/acceptance/StockAcceptance.schema.json" with { type: "json" };
+import txStockReissuanceSchema from "../../../ocf/schema/objects/transactions/reissuance/StockReissuance.schema.json" with { type: "json" };
+import txStockRepurchaseSchema from "../../../ocf/schema/objects/transactions/repurchase/StockRepurchase.schema.json" with { type: "json" };
+import txStockClassAuthorizedSharesAdjustmentSchema from "../../../ocf/schema/objects/transactions/adjustment/StockClassAuthorizedSharesAdjustment.schema.json" with { type: "json" };
+import txIssuerAuthorizedSharesAdjustmentSchema from "../../../ocf/schema/objects/transactions/adjustment/IssuerAuthorizedSharesAdjustment.schema.json" with { type: "json" };
 
 import validateInputAgainstOCF from "../../utils/validateInputAgainstSchema.js";
 import preProcessManifestTxs from "../../state-machines/process.js";

--- a/src/routes/issuer.js
+++ b/src/routes/issuer.js
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { v4 as uuid } from "uuid";
 
-import issuerSchema from "../../ocf/schema/objects/Issuer.schema.json" assert { type: "json" };
+import issuerSchema from "../../ocf/schema/objects/Issuer.schema.json" with { type: "json" };
 import deployCapTable from "../chain-operations/deployCapTable.js";
 import { createIssuer } from "../db/operations/create.js";
 import { countIssuers, readIssuerById } from "../db/operations/read.js";

--- a/src/routes/stakeholder.js
+++ b/src/routes/stakeholder.js
@@ -9,7 +9,7 @@ import {
     removeWalletFromStakeholder,
 } from "../controllers/stakeholderController.js"; // Importing the controller functions
 
-import stakeholderSchema from "../../ocf/schema/objects/Stakeholder.schema.json" assert { type: "json" };
+import stakeholderSchema from "../../ocf/schema/objects/Stakeholder.schema.json" with { type: "json" };
 import { createStakeholder } from "../db/operations/create.js";
 import { readIssuerById, readStakeholderByIssuerAssignedId, readStakeholderByIssuerAndIssuerAssignedId } from "../db/operations/read.js";
 import validateInputAgainstOCF from "../utils/validateInputAgainstSchema.js";

--- a/src/routes/stockClass.js
+++ b/src/routes/stockClass.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { v4 as uuid } from "uuid";
-import stockClassSchema from "../../ocf/schema/objects/StockClass.schema.json" assert { type: "json" };
+import stockClassSchema from "../../ocf/schema/objects/StockClass.schema.json" with { type: "json" };
 import { convertAndReflectStockClassOnchain, getStockClassById, getTotalNumberOfStockClasses } from "../controllers/stockClassController.js";
 import { createStockClass } from "../db/operations/create.js";
 import { readIssuerById } from "../db/operations/read.js";

--- a/src/routes/stockLegend.js
+++ b/src/routes/stockLegend.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { v4 as uuid } from "uuid";
-import stockLegendSchema from "../../ocf/schema/objects/StockLegendTemplate.schema.json" assert { type: "json" };
+import stockLegendSchema from "../../ocf/schema/objects/StockLegendTemplate.schema.json" with { type: "json" };
 import { createStockLegendTemplate } from "../db/operations/create.js";
 import { countStockLegendTemplates, readIssuerById, readStockLegendTemplateById } from "../db/operations/read.js";
 import validateInputAgainstOCF from "../utils/validateInputAgainstSchema.js";

--- a/src/routes/stockPlan.js
+++ b/src/routes/stockPlan.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { v4 as uuid } from "uuid";
-import stockPlanSchema from "../../ocf/schema/objects/StockPlan.schema.json" assert { type: "json" };
+import stockPlanSchema from "../../ocf/schema/objects/StockPlan.schema.json" with { type: "json" };
 import { createStockPlan } from "../db/operations/create.js";
 import { countStockPlans, readIssuerById, readStockPlanById } from "../db/operations/read.js";
 import validateInputAgainstOCF from "../utils/validateInputAgainstSchema.js";

--- a/src/routes/transactions.js
+++ b/src/routes/transactions.js
@@ -1,16 +1,16 @@
 import { Router } from "express";
 import { v4 as uuid } from "uuid";
 
-import stockAcceptanceSchema from "../../ocf/schema/objects/transactions/acceptance/StockAcceptance.schema.json" assert { type: "json" };
-import issuerAuthorizedSharesAdjustmentSchema from "../../ocf/schema/objects/transactions/adjustment/IssuerAuthorizedSharesAdjustment.schema.json" assert { type: "json" };
-import stockClassAuthorizedSharesAdjustmentSchema from "../../ocf/schema/objects/transactions/adjustment/StockClassAuthorizedSharesAdjustment.schema.json" assert { type: "json" };
-import stockCancellationSchema from "../../ocf/schema/objects/transactions/cancellation/StockCancellation.schema.json" assert { type: "json" };
-import convertibleIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/ConvertibleIssuance.schema.json" assert { type: "json" };
-import equityCompensationIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/EquityCompensationIssuance.schema.json" assert { type: "json" };
-import stockIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/StockIssuance.schema.json" assert { type: "json" };
-import stockReissuanceSchema from "../../ocf/schema/objects/transactions/reissuance/StockReissuance.schema.json" assert { type: "json" };
-import stockRepurchaseSchema from "../../ocf/schema/objects/transactions/repurchase/StockRepurchase.schema.json" assert { type: "json" };
-import stockRetractionSchema from "../../ocf/schema/objects/transactions/retraction/StockRetraction.schema.json" assert { type: "json" };
+import stockAcceptanceSchema from "../../ocf/schema/objects/transactions/acceptance/StockAcceptance.schema.json" with { type: "json" };
+import issuerAuthorizedSharesAdjustmentSchema from "../../ocf/schema/objects/transactions/adjustment/IssuerAuthorizedSharesAdjustment.schema.json" with { type: "json" };
+import stockClassAuthorizedSharesAdjustmentSchema from "../../ocf/schema/objects/transactions/adjustment/StockClassAuthorizedSharesAdjustment.schema.json" with { type: "json" };
+import stockCancellationSchema from "../../ocf/schema/objects/transactions/cancellation/StockCancellation.schema.json" with { type: "json" };
+import convertibleIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/ConvertibleIssuance.schema.json" with { type: "json" };
+import equityCompensationIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/EquityCompensationIssuance.schema.json" with { type: "json" };
+import stockIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/StockIssuance.schema.json" with { type: "json" };
+import stockReissuanceSchema from "../../ocf/schema/objects/transactions/reissuance/StockReissuance.schema.json" with { type: "json" };
+import stockRepurchaseSchema from "../../ocf/schema/objects/transactions/repurchase/StockRepurchase.schema.json" with { type: "json" };
+import stockRetractionSchema from "../../ocf/schema/objects/transactions/retraction/StockRetraction.schema.json" with { type: "json" };
 
 import { convertAndAdjustIssuerAuthorizedSharesOnChain } from "../controllers/issuerController.js";
 import { convertAndAdjustStockClassAuthorizedSharesOnchain } from "../controllers/stockClassController.js";

--- a/src/routes/valuation.js
+++ b/src/routes/valuation.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { v4 as uuid } from "uuid";
-import valuationSchema from "../../ocf/schema/objects/Valuation.schema.json" assert { type: "json" };
+import valuationSchema from "../../ocf/schema/objects/Valuation.schema.json" with { type: "json" };
 import { createValuation } from "../db/operations/create.js";
 import { countValuations, readIssuerById, readValuationById } from "../db/operations/read.js";
 import validateInputAgainstOCF from "../utils/validateInputAgainstSchema.js";

--- a/src/routes/vestingTerms.js
+++ b/src/routes/vestingTerms.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { v4 as uuid } from "uuid";
-import vestingTermsSchema from "../../ocf/schema/objects/VestingTerms.schema.json" assert { type: "json" };
+import vestingTermsSchema from "../../ocf/schema/objects/VestingTerms.schema.json" with { type: "json" };
 import { createVestingTerms } from "../db/operations/create.js";
 import { countVestingTerms, readIssuerById, readVestingTermsById } from "../db/operations/read.js";
 import validateInputAgainstOCF from "../utils/validateInputAgainstSchema.js";

--- a/src/state-machines/test.js
+++ b/src/state-machines/test.js
@@ -1,6 +1,6 @@
 import processSM from "./process.js";
-import transactions from "../../src/db/samples/data/Transactions.ocf.json" assert { type: "json" };
-import manifest from "../../src/db/samples/data/Manifest.ocf.json" assert { type: "json" };
-import stockClasses from "../../src/db/samples/data/StockClasses.ocf.json" assert { type: "json" };
+import transactions from "../../src/db/samples/data/Transactions.ocf.json" with { type: "json" };
+import manifest from "../../src/db/samples/data/Manifest.ocf.json" with { type: "json" };
+import stockClasses from "../../src/db/samples/data/StockClasses.ocf.json" with { type: "json" };
 
 processSM(manifest.issuer, transactions, stockClasses);

--- a/src/utils/getLibrariesContracts.js
+++ b/src/utils/getLibrariesContracts.js
@@ -1,5 +1,5 @@
 import { ethers } from "ethers";
-import TX_HELPER from "../../chain/out/TxHelper.sol/TxHelper.json" assert { type: "json" };
+import TX_HELPER from "../../chain/out/TxHelper.sol/TxHelper.json" with { type: "json" };
 
 const getTXLibContracts = (contractTarget, wallet) => {
     const libraries = {


### PR DESCRIPTION
## What?

•  Updates deployment infrastructure to support Plume mainnet (chain 98866) and testnet (chain 98867)
•  Rewrites `deployFactory.sh` to use `forge create `instead of `forge script `(required for Plume compatibility)
•  Adds `--verify` flag for automatic contract verification via Blockscout
•  Overhauls development documentation for clearer setup flow
•  Fixes TypeScript import errors (with instead of assert)

## Why?

Plume support: Foundry's forge script doesn't support Plume's chain ID (98866/98867) since it's not in the chain registry. Using forge create works with any chain.

•  Verification: Production deployments should be verified onchain for transparency
•  Documentation: The previous docs mixed concerns and skipped steps. Now follows a clear flow: Install → Setup → Deploy Factory → Run Server → Deploy Cap Table

## Testing

Deployed and verified all contracts on plume mainnet (but these are partial matches) need to fix that deploy script)

| Contract | Address | Explorer |
|----------|---------|----------|
| DeleteContext | `0x0707b4d24255109d323E29Fa0fB3A93ecdAE58Cf` | [View](https://explorer.plume.org/address/0x0707b4d24255109d323e29fa0fb3a93ecdae58cf) |
| Adjustment | `0x5839d9A42B720d101CcbDcba56809cb86894a233` | [View](https://explorer.plume.org/address/0x5839d9a42b720d101ccbdcba56809cb86894a233) |
| StockLib | `0x93B1bA66588fdB991eF9936FaF0433f247136942` | [View](https://explorer.plume.org/address/0x93b1ba66588fdb991ef9936faf0433f247136942) |
| CapTable | `0xa5B1C8743cE200986a2d330C4029a28a3F2c02cF` | [View](https://explorer.plume.org/address/0xa5b1c8743ce200986a2d330c4029a28a3f2c02cf) |
| CapTableFactory | `0x6bEAb9E8D8CE97c30912F74e3b74C73BA667960f` | [View](https://explorer.plume.org/address/0x6beab9e8d8ce97c30912f74e3b74c73ba667960f) |
