### PR TITLE
chore(docs)- readability and DX improvements throughout

### DIFF
--- a/WARP.md
+++ b/WARP.md
@@ -241,6 +241,18 @@ pnpm docs:start
 
 The docs are a Nextra/Next.js site in the `docs/` workspace. See `docs/README.md` for more details.
 
+### Documentation DX conventions
+
+When editing pages under `docs/src/pages/`, follow these conventions established during a readability/DX review:
+
+- **Intro paragraphs**: Use plain language. Avoid unexplained implementation terms (e.g. "beacon proxy pattern") unless the page is specifically about that concept.
+- **Price/scaling gotchas**: Surface `share_price.amount` scaling rules (÷10000) in a `<Callout type="warning">` immediately after the response overview — never only at the bottom of a page.
+- **Dependency lists**: Each tool in an install/setup page should have a one-line purpose annotation so readers understand why it is required.
+- **Setup ordering**: `pnpm install` should appear on the install page directly after `git clone`, not deferred to a later setup page.
+- **ID format explanations**: When referencing internal ID formats (e.g. bytes16/UUID-without-dashes), explain the exact format and the consequence of omitting or mismatching it.
+- **OCF import routes**: Any `multipart/form-data` route should include a concrete `curl -F` example, not just prose.
+- **Factory deploy page**: Keep changes to this page minimal — the MongoDB Compass GUI flow is intentional and should not be replaced with a CLI alternative.
+
 ### Frontend App
 
 ```bash

--- a/docs/src/pages/development/factory-deploy.mdx
+++ b/docs/src/pages/development/factory-deploy.mdx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 
 # Deploy the Factory Contract
 
-The factory contract deploys new cap tables and manages their addresses. It uses a beacon proxy pattern so all cap tables can be upgraded together.
+The factory contract is the onchain entry point for creating new cap tables. You deploy it once, then every issuer cap table is created from that single factory address.
 
 <Steps>
 

--- a/docs/src/pages/development/historical-transactions.mdx
+++ b/docs/src/pages/development/historical-transactions.mdx
@@ -26,6 +26,10 @@ The response is an array of historical transactions, each containing:
 - **`transactionType`**: The type of transaction (e.g., `StockIssuance`, `StockTransfer`)
 - **`issuer`**: The issuer ID this transaction belongs to
 
+<Callout type="warning">
+**Price scaling:** `share_price.amount` is stored as a scaled integer for onchain precision. Divide by `10000` to get the human-readable value — for example, `42000` means `$4.20`. This applies to all monetary fields in transaction responses.
+</Callout>
+
 ![Historical Transactions Response](../../../public/images/fetch-historical-transactions.png)
 
 </Steps>
@@ -51,56 +55,20 @@ The `transactionType` field indicates what kind of transaction occurred:
 ```json
 [
     {
-        "_id": "6956c8d19bfa150bf9b44b42",
-        "transaction": {
-            "_id": "ba4292ef-8234-90b7-7307-a075f2f42f5f",
-            "__v": 0,
-            "board_approval_date": "",
-            "comments": [
-                "Founder stock issuance"
-            ],
-            "consideration_text": "",
-            "cost_basis": {
-                "amount": "0",
-                "currency": "USD"
-            },
-            "createdAt": "2026-01-01T19:19:45.441Z",
-            "custom_id": "CS-A-001",
-            "date": "2026-01-01",
-            "is_onchain_synced": true,
-            "issuance_type": "",
-            "issuer": "b6ca9d9c-1daa-4b30-830b-444561ef7806",
-            "object_type": "TX_STOCK_ISSUANCE",
-            "quantity": "100000",
-            "security_id": "56d14df5-6b04-7d93-1976-5e3f0d1703de",
-            "security_law_exemptions": [],
-            "share_numbers_issued": [
-                {
-                    "starting_share_number": "0",
-                    "ending_share_number": "0"
-                }
-            ],
-            "share_price": {
-                "amount": "42000",
-                "currency": "USD"
-            },
-            "stakeholder_id": "bf40d29d-3493-4348-98a6-c69554a4b263",
-            "stock_class_id": "17dc6b51-bbfc-4f4f-8fb9-a76c167322d2",
-            "stock_legend_ids": [],
-            "stock_plan_id": "00000000-0000-0000-0000-000000000000",
-            "stockholder_approval_date": "",
-            "updatedAt": "2026-01-01T19:19:45.441Z",
-            "vesting_terms_id": "00000000-0000-0000-0000-000000000000"
-        },
         "transactionType": "StockIssuance",
-        "issuer": "b6ca9d9c-1daa-4b30-830b-444561ef7806",
-        "createdAt": "2026-01-01T19:19:45.449Z",
-        "updatedAt": "2026-01-01T19:19:45.449Z",
-        "__v": 0
+        "issuer": "<YOUR_ISSUER_ID>",
+        "transaction": {
+            "date": "2026-01-01",
+            "security_id": "56d14df5-6b04-7d93-1976-5e3f0d1703de",
+            "quantity": "100000",
+            "share_price": { "amount": "42000", "currency": "USD" },
+            "is_onchain_synced": true
+        }
     }
 ]
 ```
 
-<Callout type="info">
-Note that `share_price.amount` is stored as a scaled integer (42000 = $4.20 with 10^4 precision) for onchain accuracy.
-</Callout>
+## What's next?
+
+- Use `security_id` from a `StockIssuance` row to [transfer, cancel, or reissue](/features/corporate-actions/transfer-cancel-and-reissue-stock) that block of shares.
+- See [View Cap Table](/features/cap-table-management/view-cap-table) to read current holdings rather than full history.

--- a/docs/src/pages/development/install.mdx
+++ b/docs/src/pages/development/install.mdx
@@ -4,21 +4,21 @@ import { Callout, FileTree } from 'nextra/components'
 
 You'll need these installed to start building:
 
-- [Docker](https://docs.docker.com/get-docker/)
+- [Docker](https://docs.docker.com/get-docker/) — runs MongoDB, the server, and the frontend app locally
 
-- [Foundry](https://getfoundry.sh/)
+- [Foundry](https://getfoundry.sh/) — compiles and deploys the Solidity contracts; also provides Anvil, the local blockchain
 
 ```sh
 curl -L https://foundry.paradigm.xyz | bash
 ```
 
-- [Mongo Compass](https://www.mongodb.com/try/download/compass)
+- [MongoDB Compass](https://www.mongodb.com/try/download/compass) — GUI for inspecting the database during development
 
-- [Node.js](https://nodejs.org/en/download/)
+- [Node.js](https://nodejs.org/en/download/) — required to run the server and app
 
-- [Postman App](https://www.postman.com/downloads/)
+- [Postman](https://www.postman.com/downloads/) — for sending API requests during the walkthrough (curl works too)
 
-- [pnpm](https://pnpm.io/installation)
+- [pnpm](https://pnpm.io/installation) — the package manager used throughout this project
 
 ## Pull the repo
 
@@ -28,6 +28,11 @@ This will include the [OCF](/protocol/tap-ocf) and [Foundry](https://book.getfou
 git clone --recurse-submodules https://github.com/transfer-agent-protocol/tap-cap-table.git
 ```
 
+Then install workspace dependencies:
+
+```sh
+pnpm install
+```
 
 ## Learn the structure
 

--- a/docs/src/pages/features/_meta.js
+++ b/docs/src/pages/features/_meta.js
@@ -1,6 +1,6 @@
 const meta = {
     "issuer-management": "Manage Issuer",
-    "cap-table-management": "Create Cap Table",
+    "cap-table-management": "Manage Cap Table",
     "corporate-actions": "Corporate Actions",
 };
 

--- a/docs/src/pages/features/cap-table-management.mdx
+++ b/docs/src/pages/features/cap-table-management.mdx
@@ -1,11 +1,17 @@
 import { Cards } from 'nextra/components';
 
-# Create Cap Table
+# Manage Cap Table
 
-Use Development for the first stock class, stakeholder, and stock issuance walkthroughs. These pages cover the supporting records and read paths around that setup.
+Use this section when the issuer already exists and you need supporting records, optional acceptance, or a read of the current cap table.
+
+Use [Create Stock Class](/development/create-stock-class), [Create Stakeholder](/development/create-stakeholder), and [Issue Stock](/development/issue-stock) for the first setup flow.
 
 <Cards>
-  <Cards.Card title="Create Stock Class and Shareholders" href="/features/cap-table-management/create-stock-class-and-shareholders" />
+  <Cards.Card title="Add Supporting Records" href="/features/cap-table-management/create-stock-class-and-shareholders" />
   <Cards.Card title="Issue and Accept Stock" href="/features/cap-table-management/issue-and-accept-stock" />
   <Cards.Card title="View Cap Table" href="/features/cap-table-management/view-cap-table" />
 </Cards>
+
+- [Add Supporting Records](/features/cap-table-management/create-stock-class-and-shareholders) is for stock legends, stock plans, stakeholder wallet changes, and related read routes.
+- [Issue and Accept Stock](/features/cap-table-management/issue-and-accept-stock) is for separate stock acceptance events after issuance.
+- [View Cap Table](/features/cap-table-management/view-cap-table) is for current stock holdings by issuer.

--- a/docs/src/pages/features/cap-table-management/_meta.js
+++ b/docs/src/pages/features/cap-table-management/_meta.js
@@ -1,5 +1,5 @@
 const meta = {
-    "create-stock-class-and-shareholders": "Create Stock Class and Shareholders",
+    "create-stock-class-and-shareholders": "Add Supporting Records",
     "issue-and-accept-stock": "Issue and Accept Stock",
     "view-cap-table": "View Cap Table",
 };

--- a/docs/src/pages/features/cap-table-management/create-stock-class-and-shareholders.mdx
+++ b/docs/src/pages/features/cap-table-management/create-stock-class-and-shareholders.mdx
@@ -1,15 +1,33 @@
-import { Callout } from 'nextra/components';
+# Add Supporting Records
 
-# Create Stock Class and Shareholders
+## When to use this page
 
-Use [Create Stock Class](/development/create-stock-class) and [Create Stakeholder](/development/create-stakeholder) for the main create requests. This page covers the supporting records around that setup.
+Use this page when the stock class and stakeholder already exist and you need the supporting records around them.
 
-## Add supporting records
+Use [Create Stock Class](/development/create-stock-class) and [Create Stakeholder](/development/create-stakeholder) for the first create flow.
 
-- `POST /stock-legend/create` saves a reusable stock legend template in Mongo.
-- `POST /stock-plan/create` saves the plan record that later equity compensation issuances can reference.
+## Save a stock legend or stock plan
 
-Use [Update Valuations and Terms](/features/corporate-actions/update-valuations-and-terms) for the request bodies and read routes for those offchain records.
+Use `POST /stock-legend/create` to save reusable legend text.
+
+Use `POST /stock-plan/create` to save plan details that later equity compensation issuances can reference.
+
+```json
+{
+    "issuerId": "<YOUR_ISSUER_ID>",
+    "data": {
+        "plan_name": "Transfer Agent Protocol 2026 Plan",
+        "board_approval_date": "2026-01-15",
+        "stockholder_approval_date": "2026-01-20",
+        "initial_shares_reserved": "1000000",
+        "default_cancellation_behavior": "RETURN_TO_POOL",
+        "stock_class_id": "<YOUR_STOCK_CLASS_ID>",
+        "comments": []
+    }
+}
+```
+
+Use [Save Valuations and Terms](/features/corporate-actions/update-valuations-and-terms) for fuller examples of both create routes.
 
 ## Add or remove a stakeholder wallet
 
@@ -24,15 +42,11 @@ Use `POST /stakeholder/add-wallet` or `POST /stakeholder/remove-wallet` with thi
 
 Both routes return `"Success"` when the wallet update is accepted. `POST /stakeholder/add-wallet` can also return `"Wallet already added"`.
 
-<Callout type="info">
-Stock classes and stakeholders are created onchain and then mirrored into Mongo. Stock legends and stock plans are offchain records only.
-</Callout>
+## Read the records back
 
-## Read these records
-
-- `GET /stock-class/id/:id` returns the onchain stock class summary.
+- `GET /stock-class/id/:id` returns the stock class summary.
 - `GET /stock-class/total-number` returns the stock class count.
-- `GET /stakeholder/id/:id` returns the onchain stakeholder summary.
+- `GET /stakeholder/id/:id` returns the stakeholder summary.
 - `GET /stakeholder/issuer_assigned_id/:id`
 - `GET /stakeholder/issuer/:issuerId/issuer_assigned_id/:id`
 - `GET /stakeholder/wallet/:address`
@@ -40,6 +54,8 @@ Stock classes and stakeholders are created onchain and then mirrored into Mongo.
 - `GET /stock-legend/id/:id` and `GET /stock-legend/total-number`
 - `GET /stock-plan/id/:id` and `GET /stock-plan/total-number`
 
-## What's next?
+If you created a legend or plan, read it back by ID. If you changed a wallet, read the stakeholder by wallet address.
+
+## What to do next
 
 Use [Issue and Accept Stock](/features/cap-table-management/issue-and-accept-stock).

--- a/docs/src/pages/features/cap-table-management/issue-and-accept-stock.mdx
+++ b/docs/src/pages/features/cap-table-management/issue-and-accept-stock.mdx
@@ -2,11 +2,24 @@ import { Callout } from 'nextra/components';
 
 # Issue and Accept Stock
 
-Use [Issue Stock](/development/issue-stock) for the `POST /transactions/issuance/stock` request and response. That route creates the `StockIssuance` transaction record. This page covers `StockAcceptance`, `security_id`, and what changes after the issuance lands.
+Use this page when stock has already been issued and you want to add a separate acceptance event.
+
+Use [Issue Stock](/development/issue-stock) for the `POST /transactions/issuance/stock` request and response.
+
+## Before you use this route
+
+Acceptance is optional. Use it when you want the acceptance recorded as its own event after the original issuance.
+If the original issuance event is enough for your workflow, you do not need a separate acceptance event.
+
+- keep `stakeholderId`
+- keep `stockClassId`
+- keep `security_id`
+
+`security_id` comes from the original issuance response.
 
 ## Accept stock
 
-Use `POST /transactions/accept/stock` when you want a separate acceptance event for an existing stock security.
+Use `POST /transactions/accept/stock` when you want a separate acceptance event for an existing issuance.
 
 ```json
 {
@@ -20,26 +33,16 @@ Use `POST /transactions/accept/stock` when you want a separate acceptance event 
 }
 ```
 
-The response returns `{ "stockAcceptance": ... }` with a generated `id`, `date`, and `object_type`.
+The response returns `{ "stockAcceptance": ... }`.
 
 <Callout type="info">
-Send `stakeholderId` and `stockClassId` in the request body. TAP uses those helper fields for the contract call, then validates the OCF stock acceptance object around `security_id`.
+Keep the same `security_id` for later accept, cancel, retract, reissue, and repurchase calls on that issuance.
 </Callout>
 
-## Keep the security_id
-
-The `security_id` identifies the block of shares created by the original issuance. You use it again for:
-
-- `POST /transactions/accept/stock`
-- `POST /transactions/cancel/stock`
-- `POST /transactions/retract/stock`
-- `POST /transactions/reissue/stock`
-- `POST /transactions/repurchase/stock`
-
-## What changes after issuance or acceptance
+## Verify the result
 
 - `GET /cap-table/holdings/stock?issuerId=<YOUR_ISSUER_ID>` shows the active position once the contract state is updated.
-- `GET /historical-transactions/issuer-id/<YOUR_ISSUER_ID>` shows issuance and acceptance as separate history rows after the event poller runs.
+- `GET /historical-transactions/issuer-id/<YOUR_ISSUER_ID>` shows issuance and acceptance as separate history rows after processing.
 
 ## What's next?
 

--- a/docs/src/pages/features/cap-table-management/view-cap-table.mdx
+++ b/docs/src/pages/features/cap-table-management/view-cap-table.mdx
@@ -2,7 +2,7 @@ import { Steps, Callout } from 'nextra/components';
 
 # View Cap Table
 
-Use the cap table holdings route to see the current stock positions for an issuer. This is a hybrid read: the server starts from Mongo issuance records and then checks active positions onchain before returning the result.
+Use this page when you want to answer one question: who currently holds stock for this issuer?
 
 <Steps>
 
@@ -24,11 +24,22 @@ The response returns:
 {
     "holdings": [
         {
+            "stockClass": {
+                "_id": "<YOUR_STOCK_CLASS_ID>"
+            },
+            "stakeholder": {
+                "_id": "<YOUR_STAKEHOLDER_ID>"
+            },
             "quantity": 100000,
-            "sharePrice": 4.2
+            "sharePrice": 4.2,
+            "timestamp": 1767225600
         }
     ],
-    "stockClasses": [],
+    "stockClasses": [
+        {
+            "_id": "<YOUR_STOCK_CLASS_ID>"
+        }
+    ],
     "issuer": {
         "_id": "<YOUR_ISSUER_ID>"
     }
@@ -38,15 +49,26 @@ The response returns:
 </Steps>
 
 <Callout type="info">
-Only positions with a non-zero onchain quantity are returned. This route is currently focused on stock holdings, not option, warrant, or convertible positions.
+This route returns active stock positions only. It does not show option, warrant, or convertible positions.
 </Callout>
 
-## What this route reads
+## What this route answers
 
-- Mongo is used to find the latest stock issuances by stakeholder and stock class.
-- The cap table contract is used to confirm which positions are still active.
-- The response combines the current onchain holding with the related stakeholder and stock class records.
+- which stock positions are still active
+- which stock classes belong to the issuer
+- which issuer record the holdings belong to
+
+## What is excluded
+
+- positions with zero remaining quantity
+- non-stock instruments
+
+## How to read the result
+
+- use `holdings` to see the active stock positions
+- use `stockClasses` to map those holdings back to the stock classes
+- use `issuer` to confirm you are looking at the right cap table
 
 ## What's next?
 
-Use [Read History](/features/issuer-management/read-history) to see how the cap table got to its current state.
+Use this page for the current state. Use [View History](/features/issuer-management/read-history) when you want to see how the cap table got to that state.

--- a/docs/src/pages/features/corporate-actions.mdx
+++ b/docs/src/pages/features/corporate-actions.mdx
@@ -2,31 +2,19 @@ import { Cards } from 'nextra/components';
 
 # Corporate Actions
 
-Use this section for stock actions, offchain issuances, and maintenance records that change the cap table after the first stock issuance.
-
-Current repo surface: 11 public transaction POST routes, 43 Mongo transaction models, and 47 OCF transaction formats.
+Use this section after the first stock issuance, when you need to change holdings or save supporting data for later transactions.
 
 <Cards>
   <Cards.Card title="Transfer, Cancel, and Reissue Stock" href="/features/corporate-actions/transfer-cancel-and-reissue-stock" />
-  <Cards.Card title="Save Offchain Corporate Actions" href="/features/corporate-actions/save-offchain-corporate-actions" />
-  <Cards.Card title="Update Valuations and Terms" href="/features/corporate-actions/update-valuations-and-terms" />
+  <Cards.Card title="Save Equity Compensation and Convertibles" href="/features/corporate-actions/save-offchain-corporate-actions" />
+  <Cards.Card title="Save Valuations and Terms" href="/features/corporate-actions/update-valuations-and-terms" />
 </Cards>
 
-## Available through the API today
+- Use [Transfer, Cancel, and Reissue Stock](/features/corporate-actions/transfer-cancel-and-reissue-stock) when you are changing an existing stock issuance or adjusting authorized shares.
+- Use [Save Equity Compensation and Convertibles](/features/corporate-actions/save-offchain-corporate-actions) when you need to save equity compensation or convertible issuances through the API.
+- Use [Save Valuations and Terms](/features/corporate-actions/update-valuations-and-terms) when you need pricing, vesting, legend, plan, or stock class support records.
 
-- Stock transfer, cancellation, retraction, reissuance, repurchase, acceptance, and authorized-share adjustments.
-- Equity compensation issuance.
-- Convertible issuance.
+A few stock action formats exist in the model but not as public create routes:
 
-## Stored offchain today
-
-- Stock conversion and stock class split.
-- Equity compensation, plan security, convertible, and warrant follow-on transaction objects.
-- Vesting start, vesting event, vesting acceleration, stock plan pool adjustment, and stock class conversion ratio adjustment.
-
-## OCF only today
-
-- `EquityCompensationRepricing`
-- `StakeholderStatusChangeEvent`
-- `StakeholderRelationshipChangeEvent`
-- `StockConsolidation`
+- stock conversion and stock class split can be saved as records, but they do not have public create routes
+- stock consolidation is not available through TAP today

--- a/docs/src/pages/features/corporate-actions/_meta.js
+++ b/docs/src/pages/features/corporate-actions/_meta.js
@@ -1,7 +1,7 @@
 const meta = {
     "transfer-cancel-and-reissue-stock": "Transfer, Cancel, and Reissue Stock",
-    "save-offchain-corporate-actions": "Save Offchain Corporate Actions",
-    "update-valuations-and-terms": "Update Valuations and Terms",
+    "save-offchain-corporate-actions": "Save Equity Compensation and Convertibles",
+    "update-valuations-and-terms": "Save Valuations and Terms",
 };
 
 export default meta;

--- a/docs/src/pages/features/corporate-actions/save-offchain-corporate-actions.mdx
+++ b/docs/src/pages/features/corporate-actions/save-offchain-corporate-actions.mdx
@@ -1,16 +1,22 @@
 import { Callout } from 'nextra/components';
 
-# Save Offchain Corporate Actions
+# Save Equity Compensation and Convertibles
 
-These are the corporate actions TAP can save offchain today without sending a contract transaction. Use them when the OCF record matters now, even if the smart contract path is not yet wired up.
+Use this page when you need to save an equity compensation or convertible issuance through the API.
+
+## Before you use these routes
+
+- keep your issuer, stakeholder, and stock class IDs ready
+- equity compensation usually also needs a stock plan
+- some workflows also depend on vesting terms or valuation data
 
 <Callout type="info">
-The two public routes on this page save Mongo transaction documents but do not create `HistoricalTransaction` rows by themselves.
+These routes save the issuance for later use. They do not create a history row.
 </Callout>
 
 ## Issue equity compensation
 
-Use `POST /transactions/issuance/equity-compensation` to save an option, RSU, or SAR issuance in Mongo.
+Use `POST /transactions/issuance/equity-compensation` to save an option, RSU, or SAR issuance.
 
 ```json
 {
@@ -40,20 +46,20 @@ Use `POST /transactions/issuance/equity-compensation` to save an option, RSU, or
 }
 ```
 
-The response returns `{ "equityCompensationIssuance": ... }` and saves an `EquityCompensationIssuance` record.
+The response returns `{ "equityCompensationIssuance": ... }`.
 
-Required OCF fields:
+- Required fields:
 
-- `compensation_type`
-- `quantity`
-- `expiration_date`
-- `termination_exercise_windows`
+  - `compensation_type`
+  - `quantity`
+  - `expiration_date`
+  - `termination_exercise_windows`
 
 Options require `exercise_price`. SARs require `base_price`.
 
 ## Issue a convertible
 
-Use `POST /transactions/issuance/convertible` to save a SAFE, note, or other convertible issuance in Mongo.
+Use `POST /transactions/issuance/convertible` to save a SAFE, note, or other convertible issuance.
 
 ```json
 {
@@ -92,69 +98,21 @@ Use `POST /transactions/issuance/convertible` to save a SAFE, note, or other con
 }
 ```
 
-The response returns `{ "convertibleIssuance": ... }` and saves a `ConvertibleIssuance` record.
+The response returns `{ "convertibleIssuance": ... }`.
 
-Required OCF fields:
+- Required fields:
 
-- `convertible_type`
-- `investment_amount`
-- `conversion_triggers`
-- `seniority`
+  - `convertible_type`
+  - `investment_amount`
+  - `conversion_triggers`
+  - `seniority`
 
-## Other offchain objects TAP already stores
+## Verify the result
 
-### Equity compensation and plan securities
-
-TAP already stores these Mongo transaction objects:
-
-- `EquityCompensationAcceptance`
-- `EquityCompensationCancellation`
-- `EquityCompensationTransfer`
-- `EquityCompensationExercise`
-- `EquityCompensationRelease`
-- `EquityCompensationRetraction`
-- `PlanSecurityIssuance`
-- `PlanSecurityAcceptance`
-- `PlanSecurityCancellation`
-- `PlanSecurityTransfer`
-- `PlanSecurityExercise`
-- `PlanSecurityRelease`
-- `PlanSecurityRetraction`
-- `StockPlanReturnToPool`
-
-### Convertibles and warrants
-
-TAP already stores these Mongo transaction objects:
-
-- `ConvertibleAcceptance`
-- `ConvertibleCancellation`
-- `ConvertibleTransfer`
-- `ConvertibleRetraction`
-- `ConvertibleConversion`
-- `WarrantIssuance`
-- `WarrantAcceptance`
-- `WarrantCancellation`
-- `WarrantTransfer`
-- `WarrantRetraction`
-- `WarrantExercise`
-
-### Vesting and related adjustments
-
-TAP already stores these Mongo transaction objects:
-
-- `VestingStart`
-- `VestingEvent`
-- `VestingAcceleration`
-- `StockPlanPoolAdjustment`
-- `StockClassConversionRatioAdjustment`
-
-## OCF formats that are not stored offchain yet
-
-- `EquityCompensationRepricing`
-- `StakeholderStatusChangeEvent`
-- `StakeholderRelationshipChangeEvent`
-- `StockConsolidation`
+- keep the returned `equityCompensationIssuance` or `convertibleIssuance` object
+- read the related stock plan, vesting terms, or valuation back if the issuance depends on those inputs
+- do not expect either route to appear in [View History](/features/issuer-management/read-history)
 
 ## What's next?
 
-Use [Update Valuations and Terms](/features/corporate-actions/update-valuations-and-terms) for the offchain setup and maintenance records that support these transactions.
+Use [Save Valuations and Terms](/features/corporate-actions/update-valuations-and-terms) for the supporting records around these issuances.

--- a/docs/src/pages/features/corporate-actions/transfer-cancel-and-reissue-stock.mdx
+++ b/docs/src/pages/features/corporate-actions/transfer-cancel-and-reissue-stock.mdx
@@ -2,11 +2,21 @@ import { Callout } from 'nextra/components';
 
 # Transfer, Cancel, and Reissue Stock
 
-Use [Transfer Stock](/development/transfer-stock) for the full transfer walkthrough. This page covers the rest of the stock action routes that operate on an existing stock `security_id`.
+Use this page after a stock issuance already exists and you have its `security_id`. Use [Transfer Stock](/development/transfer-stock) for the full transfer walkthrough.
 
 <Callout type="info">
-Every route on this page is mounted under `/transactions` and creates a new onchain event instead of editing old history.
+Each route on this page adds a new history entry once it has been processed.
 </Callout>
+
+## Before you use these routes
+
+For transfer, cancel, retract, reissue, repurchase, and accept routes, keep these IDs ready:
+
+- `stakeholderId`
+- `stockClassId`
+- `security_id`
+
+`security_id` comes from the original stock issuance response. The routes below use these IDs unless noted otherwise.
 
 ## Transfer stock
 
@@ -26,51 +36,43 @@ Use `POST /transactions/transfer/stock` to move shares from one stakeholder to a
 }
 ```
 
-The route returns `"success"`. This is a TAP payload for the contract call, not a raw OCF `StockTransfer` document. The poller later creates the `StockTransfer` record and history row.
+The route returns `"success"`. Check [View Cap Table](/features/cap-table-management/view-cap-table) or [View History](/features/issuer-management/read-history) after processing to confirm the transfer.
 
-## Keep these helper fields handy
+## Change an existing security
 
-For cancel, retract, reissue, repurchase, and accept routes, send:
+### Cancel stock
 
-- `stakeholderId`
-- `stockClassId`
-- `security_id`
+- Use when: you need to cancel all or part of an existing issuance.
+- Required: `stakeholderId`, `stockClassId`, `security_id`, `quantity`
+- Optional: `balance_security_id`, `reason_text`, `comments`
+- Response: `stockCancellation`
 
-TAP uses `stakeholderId` and `stockClassId` for the contract call, then validates the OCF transaction object without those helper fields.
+### Retract stock
 
-## Cancel stock
+- Use when: you need to retract an existing issuance.
+- Required: `stakeholderId`, `stockClassId`, `security_id`
+- Optional: `reason_text`, `comments`
+- Response: `stockRetraction`
 
-Use `POST /transactions/cancel/stock` to cancel all or part of an existing stock security.
+### Reissue stock
 
-- Required data: `stakeholderId`, `stockClassId`, `security_id`, `quantity`
-- Optional data: `balance_security_id`, `reason_text`, `comments`
-- Response: `{ "stockCancellation": ... }`, which becomes a `StockCancellation` record
+- Use when: you need to replace an existing issuance with one or more resulting securities.
+- Required: `stakeholderId`, `stockClassId`, `security_id`, `resulting_security_ids`
+- Optional: `split_transaction_id`, `reason_text`, `comments`
+- Response: `stockReissuance`
 
-## Retract stock
+### Repurchase stock
 
-Use `POST /transactions/retract/stock` to retract an existing stock issuance.
+- Use when: you need to record a company repurchase.
+- Required: `stakeholderId`, `stockClassId`, `security_id`, `quantity`, `price`
+- Optional: `consideration_text`, `balance_security_id`, `comments`
+- Response: `stockRepurchase`
 
-- Required data: `stakeholderId`, `stockClassId`, `security_id`
-- Optional data: `reason_text`, `comments`
-- Response: `{ "stockRetraction": ... }`, which becomes a `StockRetraction` record
+## Adjust authorized shares
 
-## Reissue stock
+Use these routes when the company or a stock class needs a new authorized share count.
 
-Use `POST /transactions/reissue/stock` to replace an existing stock security with one or more resulting securities.
-
-- Required data: `stakeholderId`, `stockClassId`, `security_id`, `resulting_security_ids`
-- Optional data: `split_transaction_id`, `reason_text`, `comments`
-- Response: `{ "stockReissuance": ... }`, which becomes a `StockReissuance` record
-
-## Repurchase stock
-
-Use `POST /transactions/repurchase/stock` to record a company repurchase.
-
-- Required data: `stakeholderId`, `stockClassId`, `security_id`, `quantity`, `price`
-- Optional data: `consideration_text`, `balance_security_id`, `comments`
-- Response: `{ "stockRepurchase": ... }`, which becomes a `StockRepurchase` record
-
-## Adjust issuer authorized shares
+### Adjust issuer authorized shares
 
 Use `POST /transactions/adjust/issuer/authorized-shares` to change the issuer-level authorized share count.
 
@@ -86,19 +88,22 @@ Use `POST /transactions/adjust/issuer/authorized-shares` to change the issuer-le
 }
 ```
 
-The route returns `{ "issuerAuthorizedSharesAdj": ... }`, which becomes an `IssuerAuthorizedSharesAdjustment` record.
+The route returns `{ "issuerAuthorizedSharesAdj": ... }`.
 
-## Adjust stock class authorized shares
+### Adjust stock class authorized shares
 
 Use `POST /transactions/adjust/stock-class/authorized-shares` to change the authorized share count for a stock class.
 
-- Required data: `stock_class_id`, `new_shares_authorized`
-- Optional data: `board_approval_date`, `stockholder_approval_date`, `comments`
-- Response: `{ "stockClassAdjustment": ... }`, which becomes a `StockClassAuthorizedSharesAdjustment` record
+- Required fields: `stock_class_id`, `new_shares_authorized`
+- Optional fields: `board_approval_date`, `stockholder_approval_date`, `comments`
+- Response key: `stockClassAdjustment`
 
-## What shows up in historical transactions
+## Verify the result
 
-Each route on this page creates a new history row after the event poller processes the contract event:
+- Check [View Cap Table](/features/cap-table-management/view-cap-table) to confirm the current holdings.
+- Check [View History](/features/issuer-management/read-history) to confirm the new event.
+
+After processing, each route on this page appears as a separate history entry:
 
 - stock transfer
 - stock cancellation
@@ -108,12 +113,6 @@ Each route on this page creates a new history row after the event poller process
 - issuer authorized shares adjustments
 - stock class authorized shares adjustments
 
-## Other stock objects TAP understands
-
-- `StockConversion` is stored offchain today.
-- `StockClassSplit` is stored offchain today.
-- `StockConsolidation` is currently an OCF-only format.
-
 ## What's next?
 
-Use [Read History](/features/issuer-management/read-history) to verify the new event, or move to [Save Offchain Corporate Actions](/features/corporate-actions/save-offchain-corporate-actions).
+Use [View History](/features/issuer-management/read-history) to verify the new event, or move to [Save Equity Compensation and Convertibles](/features/corporate-actions/save-offchain-corporate-actions).

--- a/docs/src/pages/features/corporate-actions/update-valuations-and-terms.mdx
+++ b/docs/src/pages/features/corporate-actions/update-valuations-and-terms.mdx
@@ -1,16 +1,16 @@
 import { Callout } from 'nextra/components';
 
-# Update Valuations and Terms
+# Save Valuations and Terms
 
-These objects are the maintenance records around the cap table. They help explain pricing, vesting, legends, and plan structure, but they do not edit old history rows. In practice, you create a new record when terms change.
+Use this page when you need to save pricing, vesting, legend, plan, or stock class support data.
 
 <Callout type="info">
-Valuations, vesting terms, stock legend templates, and stock plans are saved offchain today. Stock class authorized share changes use a contract-backed adjustment route instead of editing the original stock class record.
+When terms change, create a new record. These routes do not rewrite past transactions.
 </Callout>
 
-## Add a new 409A valuation
+## Save a 409A valuation
 
-Use `POST /valuation/create` when the fair market value changes and you want the new valuation saved offchain.
+Use `POST /valuation/create` when the fair market value changes.
 
 ```json
 {
@@ -33,7 +33,9 @@ Use `POST /valuation/create` when the fair market value changes and you want the
 
 The response returns `{ "valuation": ... }`.
 
-## Add new vesting terms
+Read it back with `GET /valuation/id/:id` or `GET /valuation/total-number`.
+
+## Save vesting terms
 
 Use `POST /vesting-terms/create` to save a vesting schedule that future issuances can reference.
 
@@ -61,7 +63,9 @@ Use `POST /vesting-terms/create` to save a vesting schedule that future issuance
 
 The response returns `{ "vestingTerms": ... }`.
 
-## Add a stock legend template
+Read it back with `GET /vesting-terms/id/:id` or `GET /vesting-terms/total-number`.
+
+## Save stock legends and stock plans
 
 Use `POST /stock-legend/create` to save reusable legend text.
 
@@ -78,9 +82,9 @@ Use `POST /stock-legend/create` to save reusable legend text.
 
 The response returns `{ "stockLegend": ... }`.
 
-## Add a stock plan record
+Read it back with `GET /stock-legend/id/:id` or `GET /stock-legend/total-number`.
 
-Use `POST /stock-plan/create` to save the stock plan metadata used by future equity compensation issuances.
+Use `POST /stock-plan/create` to save the stock plan details used by future equity compensation issuances.
 
 ```json
 {
@@ -99,23 +103,20 @@ Use `POST /stock-plan/create` to save the stock plan metadata used by future equ
 
 The response returns `{ "stockPlan": ... }`.
 
-## Stock class maintenance
+Read it back with `GET /stock-plan/id/:id` or `GET /stock-plan/total-number`.
 
-For stock classes, the current maintenance flow is:
+## Maintain a stock class
 
-- use `GET /stock-class/id/:id` to read the onchain stock class summary
+Use this part of the page when you need to check the stock class record or change its authorized share count.
+
+- use `GET /stock-class/id/:id` to read the stock class summary
 - use `GET /stock-class/total-number` to count stock classes
 - use `POST /transactions/adjust/stock-class/authorized-shares` when the authorized share count changes
 
 There is no general metadata update route for stock classes today. If you need a new authorized share count, create a new adjustment event instead of editing history.
 
-## Read routes for offchain maintenance records
-
-- `GET /valuation/id/:id` and `GET /valuation/total-number`
-- `GET /vesting-terms/id/:id` and `GET /vesting-terms/total-number`
-- `GET /stock-legend/id/:id` and `GET /stock-legend/total-number`
-- `GET /stock-plan/id/:id` and `GET /stock-plan/total-number`
+Read the stock class back with `GET /stock-class/id/:id`, and use the adjustment route when the authorized share count changes.
 
 ## What's next?
 
-Use [Save Offchain Corporate Actions](/features/corporate-actions/save-offchain-corporate-actions) when those records need to be tied to equity compensation or convertible transactions.
+Use [Save Equity Compensation and Convertibles](/features/corporate-actions/save-offchain-corporate-actions) when those records need to be tied to equity compensation or convertible transactions.

--- a/docs/src/pages/features/issuer-management.mdx
+++ b/docs/src/pages/features/issuer-management.mdx
@@ -2,10 +2,18 @@ import { Cards } from 'nextra/components';
 
 # Manage Issuer
 
-Use [Create Issuer](/development/cap-table-deploy) for the first deployment. These pages cover issuer registration, reads, and history after that initial step.
+Use this section when the issuer already exists and you need one of three answers:
+
+- register or import an existing issuer
+- see what happened already
+- understand which routes create new history
 
 <Cards>
-  <Cards.Card title="Create Issuer" href="/features/issuer-management/create-issuer" />
-  <Cards.Card title="Read History" href="/features/issuer-management/read-history" />
-  <Cards.Card title="Append History" href="/features/issuer-management/append-history" />
+  <Cards.Card title="Register or Import Issuer" href="/features/issuer-management/create-issuer" />
+  <Cards.Card title="View History" href="/features/issuer-management/read-history" />
+  <Cards.Card title="Add New History" href="/features/issuer-management/append-history" />
 </Cards>
+
+- [Register or Import Issuer](/features/issuer-management/create-issuer) is for externally deployed cap tables, factory registration, and manifest imports.
+- [View History](/features/issuer-management/read-history) is for checking whether a stock action or adjustment has already been recorded.
+- [Add New History](/features/issuer-management/append-history) is for understanding which routes create a new history entry and which ones only save data.

--- a/docs/src/pages/features/issuer-management/_meta.js
+++ b/docs/src/pages/features/issuer-management/_meta.js
@@ -1,7 +1,7 @@
 const meta = {
-    "create-issuer": "Create Issuer",
-    "read-history": "Read History",
-    "append-history": "Append History",
+    "create-issuer": "Register or Import Issuer",
+    "read-history": "View History",
+    "append-history": "Add New History",
 };
 
 export default meta;

--- a/docs/src/pages/features/issuer-management/append-history.mdx
+++ b/docs/src/pages/features/issuer-management/append-history.mdx
@@ -1,8 +1,8 @@
 import { Callout } from 'nextra/components';
 
-# Append History
+# Add New History
 
-Historical transactions are append-only. You do not edit old history rows directly. To add new history, you send a new contract-backed action and let the event poller write the next row.
+Use this page when you need to know whether a route creates a new history entry or only saves data for later use.
 
 <Callout type="warning">
 You can add new events to the history feed. You cannot rewrite past events through the TAP API.
@@ -10,36 +10,43 @@ You can add new events to the history feed. You cannot rewrite past events throu
 
 ## Routes that add new history
 
-These routes send contract transactions and later create `HistoricalTransaction` rows:
+These routes add new history entries.
 
-- `POST /transactions/issuance/stock`
-- `POST /transactions/transfer/stock`
-- `POST /transactions/cancel/stock`
-- `POST /transactions/retract/stock`
-- `POST /transactions/reissue/stock`
-- `POST /transactions/repurchase/stock`
-- `POST /transactions/accept/stock`
-- `POST /transactions/adjust/issuer/authorized-shares`
-- `POST /transactions/adjust/stock-class/authorized-shares`
+- Stock actions:
+  - `POST /transactions/issuance/stock`
+  - `POST /transactions/transfer/stock`
+  - `POST /transactions/cancel/stock`
+  - `POST /transactions/retract/stock`
+  - `POST /transactions/reissue/stock`
+  - `POST /transactions/repurchase/stock`
+  - `POST /transactions/accept/stock`
+- Authorized share adjustments:
+  - `POST /transactions/adjust/issuer/authorized-shares`
+  - `POST /transactions/adjust/stock-class/authorized-shares`
 
-## Routes that do not add history on their own
+## Routes that only save data
 
-These routes save records offchain but do not create `HistoricalTransaction` rows by themselves:
+These routes save data for later use but do not add history on their own.
 
-- `POST /transactions/issuance/equity-compensation`
-- `POST /transactions/issuance/convertible`
-- `POST /stock-legend/create`
-- `POST /stock-plan/create`
-- `POST /valuation/create`
-- `POST /vesting-terms/create`
+- Equity compensation and convertibles:
+  - `POST /transactions/issuance/equity-compensation`
+  - `POST /transactions/issuance/convertible`
+- Supporting records:
+  - `POST /stock-legend/create`
+  - `POST /stock-plan/create`
+  - `POST /valuation/create`
+  - `POST /vesting-terms/create`
 
-## How to verify a history update
+## How to verify a new history entry
 
-1. Send one of the contract-backed routes listed above.
-2. Wait for the event poller to process the transaction.
+- If the route changes holdings or authorized share counts, it should appear in history.
+- If the route only saves a supporting input, it will not appear there by itself.
+
+1. Send the route.
+2. Wait for it to be processed.
 3. Fetch `GET /historical-transactions/issuer-id/<YOUR_ISSUER_ID>` again.
-4. Confirm that the new transaction appears as a new history row.
+4. Look for the new `date`, `security_id`, and transaction entry.
 
 ## What's next?
 
-Use [Transfer, Cancel, and Reissue Stock](/features/corporate-actions/transfer-cancel-and-reissue-stock) for the onchain routes that create new history. Use [Save Offchain Corporate Actions](/features/corporate-actions/save-offchain-corporate-actions) for routes that save data without updating historical transactions.
+Use [Transfer, Cancel, and Reissue Stock](/features/corporate-actions/transfer-cancel-and-reissue-stock) for routes that add new history. Use [Save Equity Compensation and Convertibles](/features/corporate-actions/save-offchain-corporate-actions) for routes that save data without adding history.

--- a/docs/src/pages/features/issuer-management/create-issuer.mdx
+++ b/docs/src/pages/features/issuer-management/create-issuer.mdx
@@ -1,12 +1,14 @@
 import { Callout } from 'nextra/components';
 
-# Create Issuer
+# Register or Import Issuer
 
-Use [Create Issuer](/development/cap-table-deploy) for the main `POST /issuer/create` flow. This page covers the issuer routes around that first deployment.
+Use this page when the issuer already exists outside the main `POST /issuer/create` flow.
 
-## Register the factory if needed
+Use [Create Issuer](/development/cap-table-deploy) for the main deployment flow.
 
-Use `POST /factory/register` once for each factory deployment.
+## Before you use these routes
+
+If the factory deployment is not in TAP yet, send `POST /factory/register` once for that factory:
 
 ```json
 {
@@ -21,27 +23,39 @@ The response returns `{ "factory": ... }`.
 
 Use `POST /issuer/register` when a wallet or another system already deployed the cap table and you only need the TAP record.
 
+Add these fields to the same issuer body used in [Create Issuer](/development/cap-table-deploy):
+
+```json
+{
+    "id": "<BYTES16_ISSUER_ID>",
+    "deployed_to": "<CAP_TABLE_ADDRESS>",
+    "tx_hash": "<DEPLOY_TX_HASH>"
+}
+```
+
+If you have the original contract `id`, send the original bytes16 value from the deployment. That keeps the registered issuer lined up with the deployed contract. If you omit `id`, the route creates a new UUID.
+
 <Callout type="info">
-Send the issuer fields from [Create Issuer](/development/cap-table-deploy), plus `deployed_to` and `tx_hash`.
+Send the same issuer fields used in [Create Issuer](/development/cap-table-deploy), plus `deployed_to` and `tx_hash`.
 </Callout>
 
-If you have the original contract `id`, send it as the bytes16 issuer ID that was used onchain. TAP converts that value back into the UUID form it uses in Mongo. If you omit `id`, the route falls back to a random UUID.
-
-Using the original onchain `id` matters most when TAP needs to line the registered issuer up with the initial `IssuerCreated` event and any manifest seeding tied to that issuer.
-
-## Read issuer records
-
-- `GET /issuer/id/:id` exists, but it is not a full issuer detail route today.
-- `GET /issuer/total-number` returns the issuer count.
-
-The `POST /issuer/create` or `POST /issuer/register` response is still the main issuer record you use in later API calls.
+The response returns `{ "issuer": ... }`. Use that issuer object in later API calls.
 
 ## Import an existing OCF cap table
 
-Use `POST /mint-cap-table` when you already have an OCF manifest and want TAP to seed Mongo, deploy the cap table, and save the resulting `deployed_to` address on the issuer.
+Use `POST /mint-cap-table` when you already have an OCF manifest and want TAP to import the cap table, deploy it, and save the resulting `deployed_to` address on the issuer.
 
 This route expects a `multipart/form-data` upload with a zip file that contains one or more `ocf.json` files.
 
+After the import finishes, use the returned issuer record for later API calls, then check [View History](/features/issuer-management/read-history) to confirm what was created.
+
+## Read issuer records
+
+- `GET /issuer/id/:id` returns a small issuer lookup, not the full issuer detail object.
+- `GET /issuer/total-number` returns the issuer count.
+
+For most workflows, the response from `POST /issuer/create` or `POST /issuer/register` is still the main issuer record you keep.
+
 ## What's next?
 
-Use [Read History](/features/issuer-management/read-history) to check what has already been recorded for the issuer.
+Use [View History](/features/issuer-management/read-history) to check what has already been recorded for the issuer.

--- a/docs/src/pages/features/issuer-management/create-issuer.mdx
+++ b/docs/src/pages/features/issuer-management/create-issuer.mdx
@@ -33,7 +33,7 @@ Add these fields to the same issuer body used in [Create Issuer](/development/ca
 }
 ```
 
-If you have the original contract `id`, send the original bytes16 value from the deployment. That keeps the registered issuer lined up with the deployed contract. If you omit `id`, the route creates a new UUID.
+If you have the original contract `id` from the deployment — a 32-hex-character value like `b6ca9d9c1daa4b30830b444561ef7806` (the UUID without dashes) — send it as the `id` field. This keeps the TAP record aligned with the deployed contract. If you omit `id`, TAP generates a new UUID, which means the TAP record won’t share the same ID as the deployed contract.
 
 <Callout type="info">
 Send the same issuer fields used in [Create Issuer](/development/cap-table-deploy), plus `deployed_to` and `tx_hash`.
@@ -46,6 +46,11 @@ The response returns `{ "issuer": ... }`. Use that issuer object in later API ca
 Use `POST /mint-cap-table` when you already have an OCF manifest and want TAP to import the cap table, deploy it, and save the resulting `deployed_to` address on the issuer.
 
 This route expects a `multipart/form-data` upload with a zip file that contains one or more `ocf.json` files.
+
+```bash
+curl -X POST http://localhost:8293/mint-cap-table \
+  -F "file=@/path/to/your-ocf-manifest.zip"
+```
 
 After the import finishes, use the returned issuer record for later API calls, then check [View History](/features/issuer-management/read-history) to confirm what was created.
 

--- a/docs/src/pages/features/issuer-management/read-history.mdx
+++ b/docs/src/pages/features/issuer-management/read-history.mdx
@@ -1,8 +1,8 @@
 import { Steps, Callout } from 'nextra/components';
 
-# Read History
+# View History
 
-Use the historical transactions route to see the event history for an issuer. This is the main read path for stock issuances, transfers, cancellations, repurchases, reissuances, retractions, acceptances, and authorized-share adjustments that were recorded through the onchain flow.
+Use this page when you want to check whether a stock action or share adjustment has already been recorded for an issuer.
 
 <Steps>
 
@@ -21,16 +21,16 @@ Replace `<YOUR_ISSUER_ID>` with the issuer `_id` from your issuer creation respo
 The response is an array. Each item includes:
 
 - `transaction` - the populated transaction document
-- `transactionType` - the Mongo model name, such as `StockIssuance`
 - `issuer` - the issuer ID
+
+Start with `transaction.date`, `transaction.security_id`, and the transaction body itself.
 
 ```json
 [
     {
-        "transactionType": "StockIssuance",
         "issuer": "<YOUR_ISSUER_ID>",
         "transaction": {
-            "object_type": "TX_STOCK_ISSUANCE",
+            "date": "2026-01-01",
             "security_id": "<YOUR_SECURITY_ID>"
         }
     }
@@ -39,27 +39,27 @@ The response is an array. Each item includes:
 
 </Steps>
 
-## What appears here today
+## Use this route to answer common checks
 
-The event poller currently writes historical rows for:
+- did my stock action land yet
+- did an authorized shares adjustment show up
+- am I looking at the right issuer history
 
-- stock issuance
-- stock transfer
-- stock cancellation
-- stock retraction
-- stock reissuance
-- stock repurchase
-- stock acceptance
-- issuer authorized shares adjustments
-- stock class authorized shares adjustments
+## Quick verification recipe
 
-## What does not appear automatically
+1. Send the stock action or share adjustment route.
+2. Fetch this history endpoint again.
+3. Look for the new `date`, `security_id`, and transaction entry.
 
-Routes that only save Mongo documents do not create history rows by themselves. That includes:
+## Why you might not see a record
+
+These routes save data but do not show up here on their own:
 
 - `POST /transactions/issuance/equity-compensation`
 - `POST /transactions/issuance/convertible`
 
+For the full list of routes that do and do not appear here, read [Add New History](/features/issuer-management/append-history).
+
 ## What's next?
 
-Read [Append History](/features/issuer-management/append-history) to see which routes add new history entries.
+Read [Add New History](/features/issuer-management/append-history) to see which routes add new history entries.

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -8,7 +8,7 @@ We use [Open Cap Table Format](/protocol/tap-ocf) and convert it into smart cont
 
 ## Current Status
 
-The protocol is live on [Plume Mainnet](https://docs.plumenetwork.xyz/plume/developer-resources/network-parameters).
+The protocol is live on [Plume Mainnet](https://docs.plume.org/plume/developer-resources/network-parameters).
 
 <Callout type="info">
 Contract addresses are unique to each deployment. When you deploy the factory, you'll get your own addresses. See the [Development Guide](/development) to get started.
@@ -22,7 +22,7 @@ The protocol has three major components.
 
 - [Offchain database](/protocol/tap-ocf) stores the cap table data. We're currently using a MongoDB that stores cap table data in the [Open Cap Table Format](/protocol/tap-ocf).
 
-- [Server](https://github.com/transfer-agent-protocol/tap-cap-table/tree/main/server/routes) that interacts with both the smart contracts and the offchain database. This server is responsible for syncing the data between the two.
+- [Server API](/features) reads and writes cap table records, then syncs them with the smart contracts.
 
 <Cards>
 	<Cards.Card title="Open Cap Table Format" href="/protocol/tap-ocf"/>

--- a/docs/src/pages/protocol/tap-ocf.mdx
+++ b/docs/src/pages/protocol/tap-ocf.mdx
@@ -28,21 +28,13 @@ Note that "stakeholder" in OCF context is more specific than the general busines
 
 ## How TAP Uses OCF Offchain
 
-OCF schemas are the validation source for TAP's offchain records. Public create routes build an OCF-shaped payload, validate it with AJV against the matching schema in `ocf/schema`, and then either call the cap table contract or save a Mongo document.
+OCF defines the JSON shapes TAP uses for offchain records. The API routes on this site use those shapes for issuers, stakeholders, stock classes, transactions, and supporting records.
 
-The current transaction surface is easiest to read in developer terms:
-
-- **Available through the API**: a REST endpoint can create or initiate the object today.
-- **Stored offchain**: TAP has a Mongo transaction object under `server/db/objects/transactions`, but no public create route for that specific action yet.
-- **OCF format available**: OCF defines the object shape, but TAP does not currently expose it as a Mongo transaction object or route.
-
-The current repo includes 47 OCF transaction object schemas and 43 TAP Mongo transaction models. The OCF transaction schemas without TAP Mongo models are `EquityCompensationRepricing`, `StakeholderRelationshipChangeEvent`, `StakeholderStatusChangeEvent`, and `StockConsolidation`.
-
-The generated OCF property reference lives under `ocf/docs/schema_markdown`. Nextra summarizes the TAP-specific API and offchain availability in the [Cap Table API](/features) guides, especially [Corporate Actions](/features/corporate-actions).
+Use the [Cap Table API](/features) guides for the routes you can call today. If you want the raw field-by-field reference, the generated schema docs live under `ocf/docs/schema_markdown`.
 
 ## Our Database
 
-Using the OCF, we've created a [database](https://github.com/transfer-agent-protocol/tap-cap-table/tree/main/server/db) schema with a Mongo implementation. This schema is used by the Transfer Agent Protocol to store and share cap table data off chain. Also found in the root folder, our db schema and the server:
+TAP stores OCF-shaped records in a [database layer](https://github.com/transfer-agent-protocol/tap-cap-table/tree/main/server/db). Also found in the root folder, our db schema and the server:
 
 <FileTree>
   <FileTree.Folder name="server" defaultOpen>


### PR DESCRIPTION
## What?

- improvements to readability and developer experience
- reorganize the features docs into clearer issuer, cap table, and corporate action flows
- rewrite features pages to focus on when to use a route, what ids or inputs are needed, how to verify the result, and what to read next
- align nav copy and page titles with the actual job each page does
- improve install, factory deploy, issuer import, and historical transaction guidance

## Why?

- the docs were mixing walkthroughs, route inventory, and internal implementation details in ways that made them harder to scan
- several page titles and sidebar labels did not match the content, which made navigation harder than it needed to be
- these weren't great: setup, issuer import, and reading transaction history

## Testing

- pnpm docs:build
- manually reviewed all features pages for readability and task flow
- spot-checked development pages updated in this branch
- verified docs routes render after the nextra config and footer fixes