### PR TITLE
Feat/mint fullscreen cap table ops

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ PRIVATE_KEY=UPDATE_ME
 # Server port
 PORT=8293
 
+# Number of issuers processed concurrently per polling cycle (poller is slated for
+# replacement by an indexer; this is the single tuning knob it exposes).
+POLLER_MAX_CONCURRENCY=8
+
 # --- Frontend (app/) ---
 
 # Reown (WalletConnect) project ID — get one at https://cloud.reown.com
@@ -41,4 +45,3 @@ NEXT_PUBLIC_API_URL=http://localhost:8293
 # Server wallet address to receive OPERATOR_ROLE on newly created cap tables
 # This is the address derived from PRIVATE_KEY above
 NEXT_PUBLIC_OPERATOR_ADDRESS=UPDATE_ME
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
             - name: Setup Node
@@ -14,13 +14,13 @@ jobs:
               with:
                   node-version: "lts/*"
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
             - name: Get pnpm store directory
               shell: bash
               run: |
                   echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
             - name: Setup pnpm cache
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                   path: ${{ env.STORE_PATH }}
                   key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,7 @@ jobs:
             security-events: write
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
 
@@ -48,7 +48,7 @@ jobs:
 
             - name: Upload Slither report
               if: always()
-              uses: actions/upload-artifact@v6
+              uses: actions/upload-artifact@v7
               with:
                   name: slither-report
                   path: slither.sarif
@@ -58,7 +58,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
 

--- a/WARP.md
+++ b/WARP.md
@@ -61,12 +61,18 @@ The factory uses OpenZeppelin's `UpgradeableBeacon` — each cap table is a `Bea
     - Processes events through XState state machines (`server/state-machines/`)
     - Synchronizes onchain state to MongoDB
     - Can run in two modes: `--finalized-only` (production) or latest blocks (testing)
+    - **Slated for replacement by a proper indexer.** Kept intentionally simple: round-robin across issuers with `runWithConcurrency` (`POLLER_MAX_CONCURRENCY`, default 5). Per-cycle query window is `maxBlocks=5000` (raised from the historical 500 to drain backlog faster on fast chains like Plume) with a `maxEvents=250` safety cap per DB transaction. Do not re-add prioritization/backoff/dynamic-sleep machinery — the indexer will obviate it.
 
 3. **Express API** (`server/app.js`, `server/routes/`):
     - REST endpoints for issuers, stakeholders, stock classes, transactions, etc.
     - Validates input against OCF schemas (`ocf/schema/`)
     - Submits transactions to smart contracts
     - Routes: `/cap-table`, `/factory`, `/issuer`, `/stakeholder`, `/stock-class`, `/transactions`, etc.
+    - **Two route conventions** for entity creation:
+      - `POST /<entity>/create` — server-signed (server's OPERATOR key submits onchain, then persists metadata). Legacy default.
+      - `POST /<entity>/register-onchain` — caller's wallet already submitted onchain (direct flow); endpoint only validates + persists metadata. The poller is still authoritative for the resulting record. Currently exposed for `/stakeholder`, `/stock-class`, and `/transactions/issuance/stock`.
+    - `GET /issuer/by-deployer/:address` — list issuers a given admin wallet deployed (uses the new `Issuer.deployed_by` field).
+    - `GET /issuer/full/:id` — full Issuer document (read-only) for the management UI.
 
 4. **State Machines** (`server/state-machines/`):
     - XState machines model stock lifecycle: Issued → Transferred/Cancelled/Retracted/Reissued/Repurchased
@@ -81,15 +87,26 @@ The factory uses OpenZeppelin's `UpgradeableBeacon` — each cap table is a `Bea
     - JSON schemas used for validation
     - Sample OCF files in `ocf/samples/`
 
+7. **Frontend Cap Table Management UI** (`app/src/pages/manage/`, `app/src/components/CapTableDashboard.tsx`):
+    - `/manage` — hub listing all cap tables the connected admin wallet has deployed (queries `/issuer/by-deployer/:address` + a localStorage fallback for legacy mints with no `deployed_by`).
+    - `/manage/cap-table?issuerId=...` — full-screen dashboard for a specific cap table. Forms create stock classes, stakeholders, and stock issuances directly from the connected wallet.
+    - Optimistic state for direct creations carries a 90s TTL — the chain assigns issuance ids internally, so we can't reliably match optimistic items to poller-written records.
+
 ### Data Flow
 
-**Transaction Creation**:
+**Transaction Creation (server-signed, legacy)**:
 
-1. API receives OCF-formatted transaction request
+1. API receives OCF-formatted transaction request at `/<entity>/create`
 2. Validates against OCF schema
-3. Converts to Solidity structs and submits to contract
+3. Converts to Solidity structs and submits to contract via the server's OPERATOR key
 4. Transaction emits events onchain
 5. Event poller picks up events and updates MongoDB
+
+**Transaction Creation (direct wallet, current default for the `/manage` UI)**:
+
+1. Frontend generates a bytes16 id and submits the tx from the connected admin wallet via wagmi (`useDirectCreateStockClass`, `useDirectCreateStakeholder`, `useDirectIssueStock`). The chain assigns issuance + security ids internally for `issueStock`; the frontend supplies its own ids only for `createStakeholder` and `createStockClass`.
+2. Frontend POSTs OCF metadata to `/<entity>/register-onchain`. Server validates and persists offchain metadata; **does not** submit onchain again.
+3. The poller is still authoritative — it picks up the TxCreated/StakeholderCreated/StockClassCreated event and writes the canonical record (joining on the bytes16 id where applicable).
 
 **Minting**:
 When a manifest is created, the system:
@@ -338,6 +355,7 @@ Share quantities and prices use scaled BigNumbers (1e10 precision):
 
 - `toScaledBigNumber(value)` to convert before contract calls
 - Always scale quantities and prices in transaction parameters
+- The poller unscales by 1e10 on read (`toDecimal()` in `transactionHandlers.js`). Any new direct-wallet path must scale on the write side to match — see `app/src/hooks/useDirectIssueStock.ts` where `scaleAmount` (1e10) is applied to both `quantity` and `share_price`.
 
 ### OCF Validation
 
@@ -388,6 +406,7 @@ The system supports multiple environments via `.env` files:
 - `NEXT_PUBLIC_CHAIN_ID`: Chain ID the frontend targets
 - `NEXT_PUBLIC_API_URL`: API server URL (default `http://localhost:8293`)
 - `NEXT_PUBLIC_OPERATOR_ADDRESS`: Server wallet address to receive OPERATOR_ROLE on new cap tables
+- `POLLER_MAX_CONCURRENCY`: Number of issuers processed in parallel per polling cycle (default 5, raised to 8 in `docker-compose.yml`). The only tuning knob the poller exposes; will be removed when the indexer replaces it.
 
 ## Working with OCF
 
@@ -484,13 +503,15 @@ Libraries:
 
 ## Common Pitfalls
 
-1. **Forgetting to scale numbers**: Always use `toScaledBigNumber()` for quantities and prices
-2. **UUID format mismatch**: Convert UUIDs to bytes16 before contract calls
-3. **Poller not running**: Transactions won't sync to DB without the event poller
-4. **Missing replica set**: Atomic operations fail without `DATABASE_REPLSET=1`
-5. **OCF validation skipped**: Always validate input against schemas
-6. **Contract events not emitted**: Check that contract functions emit expected events
-7. **Preprocessor cache not populated**: Ensure seeding happens after manifest creation
+1. **Forgetting to scale numbers**: Always use `toScaledBigNumber()` for quantities and prices. Direct-wallet hooks must scale on the write side or the poller's 1e10 unscale will produce tiny fractions in Mongo (e.g. `69000` raw → `0.0000069` after unscale).
+2. **UUID format mismatch**: Convert UUIDs to bytes16 before contract calls.
+3. **Poller not running**: Transactions won't sync to DB without the event poller.
+4. **Missing replica set**: Atomic operations fail without `DATABASE_REPLSET=1`.
+5. **OCF validation skipped**: Always validate input against schemas.
+6. **Contract events not emitted**: Check that contract functions emit expected events.
+7. **Preprocessor cache not populated**: Ensure seeding happens after manifest creation.
+8. **Mixing `/create` and `/register-onchain` semantics**: `/create` makes the server submit onchain; `/register-onchain` assumes the caller already did. Don't reintroduce a `suppliedId`-style overload on the `/create` route — that pattern was explicitly removed.
+9. **Optimistic-state dedupe by stakeholder+stockclass**: Don't. Multiple issuances can exist for the same pair; deduping there hides legitimate in-flight rows. Use a TTL (current: 90s) and let the aggregated holding row absorb the new total once the poller catches up.
 
 ## Debugging
 

--- a/app/next-env.d.ts
+++ b/app/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/app/public/sitemap-0.xml
+++ b/app/public/sitemap-0.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://transferagentprotocol.xyz</loc><lastmod>2026-04-05T15:38:23.543Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://transferagentprotocol.xyz/mint</loc><lastmod>2026-04-05T15:38:23.544Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://transferagentprotocol.xyz</loc><lastmod>2026-05-24T22:45:41.229Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://transferagentprotocol.xyz/manage</loc><lastmod>2026-05-24T22:45:41.230Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://transferagentprotocol.xyz/manage/cap-table</loc><lastmod>2026-05-24T22:45:41.230Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://transferagentprotocol.xyz/mint</loc><lastmod>2026-05-24T22:45:41.230Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/app/src/components/CapTableDashboard.tsx
+++ b/app/src/components/CapTableDashboard.tsx
@@ -1,0 +1,452 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+	ActionTableLayout,
+	FullScreenStack,
+	Panel,
+	SectionHeader,
+	StatusBox,
+	StyledTable,
+	TablePanel,
+	TableScroll,
+	TableTitle,
+} from "./wrappers";
+import { IssuerHeader } from "./IssuerHeader";
+import { StockClassForm } from "./StockClassForm";
+import { StakeholderForm } from "./StakeholderForm";
+import { IssueStockForm } from "./IssueStockForm";
+import { HoldingsTable } from "./HoldingsTable";
+import { MintNavDrawer, type MintView } from "./MintNavDrawer";
+import { TxSuccessModal } from "./TxSuccessModal";
+import { useCapTableMenu } from "./CapTableMenuContext";
+import { useCapTableManager } from "../hooks/useCapTableManager";
+import { useDirectCreateStockClass } from "../hooks/useDirectCreateStockClass";
+import { useDirectCreateStakeholder } from "../hooks/useDirectCreateStakeholder";
+import { useDirectIssueStock } from "../hooks/useDirectIssueStock";
+import { bytes16ToUuid, generateBytes16Id } from "../utils/uuid";
+import { fetchHistoricalTransactions } from "../services/fetchHistoricalTransactions";
+import { registerStockClassOnchain, type StockClassData } from "../services/createStockClass";
+import { registerStakeholderOnchain, type StakeholderData } from "../services/createStakeholder";
+import { registerStockIssuanceOnchain, type StockIssuanceData } from "../services/createStockIssuance";
+import type { IssuerResponse } from "../services/registerIssuer";
+
+interface CapTableDashboardProps {
+	issuerResult: IssuerResponse;
+	onReset: () => void;
+}
+
+interface PendingModal {
+	title: string;
+	message?: string;
+}
+
+export function CapTableDashboard({ issuerResult, onReset }: CapTableDashboardProps) {
+	const manager = useCapTableManager(issuerResult);
+	const directStockClass = useDirectCreateStockClass();
+	const directStakeholder = useDirectCreateStakeholder();
+	const directIssuance = useDirectIssueStock();
+
+	const capTableAddress = issuerResult.deployed_to as `0x${string}` | undefined;
+
+	const [currentView, setCurrentView] = useState<MintView>("overview");
+	const { isOpen: isDrawerOpen, setOpen: setIsDrawerOpen, setEnabled: setMenuEnabled } = useCapTableMenu();
+
+	// Tell the navbar that the menu trigger is meaningful while this dashboard
+	// is mounted; clean up so other routes don't render the trigger.
+	useEffect(() => {
+		setMenuEnabled(true);
+		return () => {
+			setMenuEnabled(false);
+			setIsDrawerOpen(false);
+		};
+	}, [setMenuEnabled, setIsDrawerOpen]);
+
+	// Local optimistic state for items created via direct wallet signing in this session.
+	interface OptimisticStockClass { _id: string; name: string; class_type: string; }
+	interface OptimisticStakeholder { _id: string; name: any; stakeholder_type: string; }
+	interface OptimisticIssuance {
+		_id: string;
+		security_id: string;
+		quantity: string;
+		stakeholder_id: string;
+		stock_class_id: string;
+	}
+
+	const [directStockClasses, setDirectStockClasses] = useState<OptimisticStockClass[]>([]);
+	const [directStakeholders, setDirectStakeholders] = useState<OptimisticStakeholder[]>([]);
+	const [directIssuances, setDirectIssuances] = useState<OptimisticIssuance[]>([]);
+
+	// Pending success modals: filled in on submit; the txHash is patched in via useEffect once
+	// the wagmi hook surfaces it. writeContract returns synchronously but `hash` populates async.
+	const [pendingStockClass, setPendingStockClass] = useState<PendingModal | null>(null);
+	const [pendingStakeholder, setPendingStakeholder] = useState<PendingModal | null>(null);
+	const [pendingIssuance, setPendingIssuance] = useState<PendingModal | null>(null);
+
+	const [successModal, setSuccessModal] = useState<{ title: string; txHash?: string; message?: string } | null>(null);
+
+	// Historical transactions for the Activity view (poller-populated)
+	const [historicalTransactions, setHistoricalTransactions] = useState<any[]>([]); // TODO: proper HistoricalTransaction type
+	const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+
+	// When the direct hooks finally surface a hash, open the corresponding success modal.
+	// These effects exist because wagmi's writeContract is async — the `hash` field on the hook
+	// becomes defined a tick after the function call returns, so reading it inside the submit
+	// handler always gets undefined.
+	useEffect(() => {
+		if (directStockClass.hash && pendingStockClass) {
+			setSuccessModal({ ...pendingStockClass, txHash: directStockClass.hash });
+			setPendingStockClass(null);
+			directStockClass.reset();
+		}
+	}, [directStockClass.hash, pendingStockClass, directStockClass]);
+
+	useEffect(() => {
+		if (directStakeholder.hash && pendingStakeholder) {
+			setSuccessModal({ ...pendingStakeholder, txHash: directStakeholder.hash });
+			setPendingStakeholder(null);
+			directStakeholder.reset();
+		}
+	}, [directStakeholder.hash, pendingStakeholder, directStakeholder]);
+
+	useEffect(() => {
+		if (directIssuance.hash && pendingIssuance) {
+			setSuccessModal({ ...pendingIssuance, txHash: directIssuance.hash });
+			setPendingIssuance(null);
+			directIssuance.reset();
+		}
+	}, [directIssuance.hash, pendingIssuance, directIssuance]);
+
+	// Lazy-load historical transactions when the Activity view is opened.
+	useEffect(() => {
+		if (currentView !== "activity" || !issuerResult?._id) return;
+		setIsLoadingHistory(true);
+		fetchHistoricalTransactions(issuerResult._id)
+			.then((res: any) => setHistoricalTransactions(Array.isArray(res?.transactions) ? res.transactions : res || [])) // TODO: proper type
+			.catch((err) => console.warn("Failed to load historical transactions", err))
+			.finally(() => setIsLoadingHistory(false));
+	}, [currentView, issuerResult?._id]);
+
+	// Build options for the Issue form + drawer from holdings + optimistic + direct onchain creates
+	const stockClassOptions = useMemo(() => {
+		const fromHoldings = manager.holdings?.stockClasses || [];
+		return [...fromHoldings, ...manager.createdStockClasses, ...directStockClasses].filter(Boolean);
+	}, [manager.holdings?.stockClasses, manager.createdStockClasses, directStockClasses]);
+
+	const stakeholderOptions = useMemo(() => {
+		const fromHoldings = (manager.holdings?.holdings || []).map((h: { stakeholder?: any }) => h.stakeholder).filter(Boolean);
+		return [...fromHoldings, ...manager.createdStakeholders, ...directStakeholders].filter(Boolean);
+	}, [manager.holdings?.holdings, manager.createdStakeholders, directStakeholders]);
+
+	const handleStockClass = async (data: StockClassData) => {
+		if (!capTableAddress || !directStockClass.isConnected) {
+			setSuccessModal({
+				title: "Wallet Required",
+				message: "Please connect your wallet (as Admin) to create a stock class onchain.",
+			});
+			return;
+		}
+
+		try {
+			// One id is used for both the onchain bytes16 and the offchain _id (UUID form). The poller's
+			// updateStockClassById converts the event's bytes16 back to this same UUID for sync.
+			const stockClassBytes16 = generateBytes16Id() as `0x${string}`;
+			const stockClassUuid = bytes16ToUuid(stockClassBytes16);
+
+			await directStockClass.createStockClass({
+				capTableAddress,
+				classType: data.class_type,
+				pricePerShareAmount: data.price_per_share?.amount || "0",
+				initialSharesAuthorized: data.initial_shares_authorized,
+				id: stockClassBytes16,
+			});
+
+			setPendingStockClass({
+				title: "Stock Class Created Onchain",
+				message: "Your wallet successfully submitted the transaction to the CapTable contract.",
+			});
+
+			setDirectStockClasses((prev) => [...prev, { _id: stockClassUuid, name: data.name, class_type: data.class_type }]);
+
+			registerStockClassOnchain({ issuerId: issuerResult._id, data, id: stockClassUuid }).catch((err) =>
+				console.warn("Failed to register stock class metadata:", err),
+			);
+
+			manager.refreshHoldings();
+		} catch (err) {
+			console.error("Direct stock class creation failed", err);
+			setSuccessModal({
+				title: "Transaction Failed",
+				message: "Failed to create stock class onchain. Check the console for details.",
+			});
+		}
+	};
+
+	const handleStakeholder = async (data: StakeholderData) => {
+		if (!capTableAddress || !directStakeholder.isConnected) {
+			setSuccessModal({
+				title: "Wallet Required",
+				message: "Please connect your wallet (as Admin) to create a stakeholder onchain.",
+			});
+			return;
+		}
+
+		try {
+			const stakeholderBytes16 = generateBytes16Id() as `0x${string}`;
+			const stakeholderUuid = bytes16ToUuid(stakeholderBytes16);
+
+			await directStakeholder.createStakeholder({
+				capTableAddress,
+				stakeholderType: data.stakeholder_type,
+				currentRelationship: data.current_relationship,
+				id: stakeholderBytes16,
+			});
+
+			setPendingStakeholder({
+				title: "Stakeholder Created Onchain",
+				message: "Your wallet successfully submitted the transaction.",
+			});
+
+			setDirectStakeholders((prev) => [
+				...prev,
+				{ _id: stakeholderUuid, name: data.name, stakeholder_type: data.stakeholder_type },
+			]);
+
+			registerStakeholderOnchain({ issuerId: issuerResult._id, data, id: stakeholderUuid }).catch((err) =>
+				console.warn("Failed to register stakeholder metadata:", err),
+			);
+
+			manager.refreshHoldings();
+		} catch (err) {
+			console.error("Direct stakeholder creation failed", err);
+			setSuccessModal({
+				title: "Transaction Failed",
+				message: "Failed to create stakeholder onchain.",
+			});
+		}
+	};
+
+	const handleIssuance = async (data: StockIssuanceData) => {
+		if (!capTableAddress || !directIssuance.isConnected) {
+			setSuccessModal({
+				title: "Wallet Required",
+				message: "Please connect your wallet (as Admin) to issue stock onchain.",
+			});
+			return;
+		}
+
+		try {
+			const result = await directIssuance.issueStock({
+				capTableAddress,
+				stakeholderId: data.stakeholder_id,
+				stockClassId: data.stock_class_id,
+				quantity: data.quantity,
+				sharePriceAmount: data.share_price?.amount || "0",
+				customId: data.custom_id,
+				comments: data.comments,
+			});
+
+			setPendingIssuance({
+				title: "Stock Issued Onchain",
+				message: "Your wallet successfully submitted the issuance transaction.",
+			});
+
+			setDirectIssuances((prev) => [
+				...prev,
+				{
+					_id: result.issuanceId,
+					security_id: result.securityId,
+					quantity: data.quantity,
+					stakeholder_id: data.stakeholder_id,
+					stock_class_id: data.stock_class_id,
+				},
+			]);
+
+			registerStockIssuanceOnchain({ issuerId: issuerResult._id, data }).catch((err) =>
+				console.warn("Failed to register stock issuance metadata:", err),
+			);
+
+			manager.refreshHoldings();
+		} catch (err) {
+			console.error("Direct stock issuance failed", err);
+			setSuccessModal({
+				title: "Transaction Failed",
+				message: "Failed to issue stock onchain.",
+			});
+		}
+	};
+
+	const handleNavigate = (view: MintView) => {
+		setCurrentView(view);
+	};
+
+	const renderMainContent = () => {
+		if (currentView === "stock-classes") {
+			return (
+				<ActionTableLayout>
+					<Panel>
+						<SectionHeader>
+							<TableTitle>Create Stock Class</TableTitle>
+						</SectionHeader>
+						<StockClassForm onSubmit={handleStockClass} />
+					</Panel>
+					<TablePanel>
+						<HoldingsTable
+							holdingsData={manager.holdings}
+							createdStockClasses={[...manager.createdStockClasses, ...directStockClasses]}
+							createdStakeholders={[...manager.createdStakeholders, ...directStakeholders]}
+							createdIssuances={[...manager.createdIssuances, ...directIssuances]}
+							onRefresh={manager.refreshHoldings}
+							isLoading={manager.isLoadingHoldings}
+						/>
+					</TablePanel>
+				</ActionTableLayout>
+			);
+		}
+
+		if (currentView === "stakeholders") {
+			return (
+				<ActionTableLayout>
+					<Panel>
+						<SectionHeader>
+							<TableTitle>Create Stakeholder</TableTitle>
+						</SectionHeader>
+						<StakeholderForm onSubmit={handleStakeholder} />
+					</Panel>
+					<TablePanel>
+						<HoldingsTable
+							holdingsData={manager.holdings}
+							createdStockClasses={[...manager.createdStockClasses, ...directStockClasses]}
+							createdStakeholders={[...manager.createdStakeholders, ...directStakeholders]}
+							createdIssuances={[...manager.createdIssuances, ...directIssuances]}
+							onRefresh={manager.refreshHoldings}
+							isLoading={manager.isLoadingHoldings}
+						/>
+					</TablePanel>
+				</ActionTableLayout>
+			);
+		}
+
+		if (currentView === "activity") {
+			return (
+				<TablePanel>
+					<SectionHeader>
+						<TableTitle>Recent Activity (Historical Transactions)</TableTitle>
+					</SectionHeader>
+					{historicalTransactions.length > 0 ? (
+						<TableScroll>
+							<StyledTable>
+								<thead>
+									<tr>
+										<th>Type</th>
+										<th>Details</th>
+										<th>Quantity</th>
+										<th>Price</th>
+										<th>Date</th>
+									</tr>
+								</thead>
+								<tbody>
+									{historicalTransactions.map((tx: any, idx: number) => { // TODO: type HistoricalTransaction
+										const t = tx.transaction || {};
+										return (
+											<tr key={idx}>
+												<td>{tx.transactionType}</td>
+												<td style={{ fontSize: "0.8rem" }}>
+													{t.custom_id || t.security_id?.slice(0, 8) || "—"}
+												</td>
+												<td style={{ fontFamily: "monospace" }}>{t.quantity}</td>
+												<td>
+													{t.share_price?.amount
+														? `${(parseInt(t.share_price.amount) / 10000).toFixed(2)} ${t.share_price.currency}`
+														: "—"}
+												</td>
+												<td>{t.date || "—"}</td>
+											</tr>
+										);
+									})}
+								</tbody>
+							</StyledTable>
+						</TableScroll>
+					) : (
+						<div style={{ padding: "1rem", opacity: 0.6 }}>
+							No historical transactions yet. Issue stock to see activity here.
+							{isLoadingHistory && " (loading...)"}
+						</div>
+					)}
+
+					<HoldingsTable
+						holdingsData={manager.holdings}
+						createdIssuances={[...manager.createdIssuances, ...directIssuances]}
+						onRefresh={manager.refreshHoldings}
+					/>
+				</TablePanel>
+			);
+		}
+
+		// Default: Overview
+		return (
+			<ActionTableLayout>
+				<Panel>
+					<StockClassForm onSubmit={handleStockClass} disabled={manager.isLoadingHoldings} />
+					<StakeholderForm onSubmit={handleStakeholder} disabled={manager.isLoadingHoldings} />
+					<IssueStockForm
+						stockClasses={stockClassOptions}
+						stakeholders={stakeholderOptions}
+						onSubmit={handleIssuance}
+						disabled={manager.isLoadingHoldings || stockClassOptions.length === 0 || stakeholderOptions.length === 0}
+					/>
+				</Panel>
+
+				<TablePanel>
+					<HoldingsTable
+						holdingsData={manager.holdings}
+						createdStockClasses={[...manager.createdStockClasses, ...directStockClasses]}
+						createdStakeholders={[...manager.createdStakeholders, ...directStakeholders]}
+						createdIssuances={[...manager.createdIssuances, ...directIssuances]}
+						onRefresh={manager.refreshHoldings}
+						isLoading={manager.isLoadingHoldings}
+					/>
+				</TablePanel>
+			</ActionTableLayout>
+		);
+	};
+
+	return (
+		<FullScreenStack>
+			<IssuerHeader
+				issuer={issuerResult}
+				contractAddress={manager.contractAddress}
+				onReset={onReset}
+			/>
+
+			{(manager.lastError || manager.holdingsError) && (
+				<StatusBox $variant="error">
+					{manager.lastError || manager.holdingsError}
+				</StatusBox>
+			)}
+
+			{renderMainContent()}
+
+			<MintNavDrawer
+				isOpen={isDrawerOpen}
+				onClose={() => setIsDrawerOpen(false)}
+				currentView={currentView}
+				onNavigate={handleNavigate}
+				stockClasses={[...manager.createdStockClasses, ...directStockClasses].map((sc) => ({
+					_id: sc._id,
+					name: sc.name,
+				}))}
+				stakeholders={[...manager.createdStakeholders, ...directStakeholders].map((sh) => ({
+					_id: sh._id,
+					name: sh.name,
+				}))}
+			/>
+
+			<TxSuccessModal
+				isOpen={!!successModal}
+				onClose={() => setSuccessModal(null)}
+				title={successModal?.title || ""}
+				txHash={successModal?.txHash}
+				message={successModal?.message}
+			/>
+		</FullScreenStack>
+	);
+}

--- a/app/src/components/CapTableMenuContext.tsx
+++ b/app/src/components/CapTableMenuContext.tsx
@@ -1,0 +1,40 @@
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+interface CapTableMenuValue {
+	isOpen: boolean;
+	setOpen: (open: boolean) => void;
+	isEnabled: boolean;
+	setEnabled: (enabled: boolean) => void;
+}
+
+const CapTableMenuContext = createContext<CapTableMenuValue | null>(null);
+
+export function CapTableMenuProvider({ children }: { children: ReactNode }) {
+	const [isOpen, setOpen] = useState(false);
+	const [isEnabled, setEnabled] = useState(false);
+	return (
+		<CapTableMenuContext.Provider value={{ isOpen, setOpen, isEnabled, setEnabled }}>
+			{children}
+		</CapTableMenuContext.Provider>
+	);
+}
+
+/**
+ * Hook for components that want to read/control the cap-table menu drawer.
+ *
+ * The provider is wired into `_app.tsx`, but this hook returns a safe no-op
+ * default if it is rendered outside of a provider so that downstream
+ * components don't need to special-case missing context (e.g. during tests).
+ */
+export function useCapTableMenu(): CapTableMenuValue {
+	const ctx = useContext(CapTableMenuContext);
+	if (!ctx) {
+		return {
+			isOpen: false,
+			setOpen: () => {},
+			isEnabled: false,
+			setEnabled: () => {},
+		};
+	}
+	return ctx;
+}

--- a/app/src/components/HoldingsTable.tsx
+++ b/app/src/components/HoldingsTable.tsx
@@ -1,0 +1,171 @@
+import { MutedText, SectionActions, SectionHeader, StyledTable, TableScroll, TableTitle } from "./wrappers";
+import { InlineButton } from "./buttons";
+
+interface HoldingsTableProps {
+	holdingsData: any; // debug/hybrid data from /cap-table/holdings/stock + optimistic direct creations
+	createdStockClasses?: any[];
+	createdStakeholders?: any[];
+	createdIssuances?: any[];
+	onRefresh?: () => void;
+	isLoading?: boolean;
+}
+
+function formatSharePrice(sharePrice: unknown, currency: string = "USD"): string {
+	if (sharePrice == null) return "—";
+	// Server (`/cap-table/holdings/stock`) returns sharePrice as a plain number
+	// (`Number(quantityPrice / quantity) / decimalScaleValue`). Optimistic rows
+	// constructed client-side use the OCF shape `{ amount, currency }`.
+	if (typeof sharePrice === "number") {
+		if (!Number.isFinite(sharePrice) || sharePrice === 0) return "—";
+		return `${sharePrice.toFixed(2)} ${currency}`;
+	}
+	if (typeof sharePrice === "object") {
+		const s = sharePrice as { amount?: string | number; currency?: string };
+		if (s.amount == null || s.amount === "" || s.amount === "0") return "—";
+		return `${s.amount} ${s.currency || currency}`;
+	}
+	return "—";
+}
+
+export function HoldingsTable({ holdingsData, createdStockClasses = [], createdStakeholders = [], createdIssuances = [], onRefresh, isLoading }: HoldingsTableProps) {
+	const holdings = holdingsData?.holdings || [];
+
+	// Drop optimistic issuances once a matching real row arrives from the server. We dedupe on
+	// stakeholder_id + stock_class_id because that's the join key the poller uses to materialize
+	// a holding row, and the optimistic item carries those ids from the issuance form.
+	const holdingKeys = new Set<string>(
+		holdings.map((h: any) => `${h.stakeholder?._id}|${h.stockClass?._id}`),
+	);
+	const pendingIssuances = createdIssuances.filter(
+		(iss: any) => !holdingKeys.has(`${iss.stakeholder_id}|${iss.stock_class_id}`),
+	);
+
+
+	return (
+		<div>
+			<SectionHeader>
+				<TableTitle>Cap Table Holdings (live from server + optimistic)</TableTitle>
+				{onRefresh && (
+					<SectionActions>
+						<InlineButton onClick={onRefresh} disabled={isLoading}>
+							{isLoading ? "Refreshing..." : "Refresh"}
+						</InlineButton>
+						<InlineButton
+							onClick={onRefresh}
+							disabled={isLoading}
+							title="Force re-fetch from MongoDB (bypasses cache)"
+						>
+							Force DB Refresh
+						</InlineButton>
+					</SectionActions>
+				)}
+			</SectionHeader>
+
+			<TableScroll>
+			<StyledTable>
+				<thead>
+					<tr>
+						<th>Stakeholder</th>
+						<th>Stock Class</th>
+						<th>Quantity</th>
+						<th>Share Price</th>
+						<th>Status</th>
+					</tr>
+				</thead>
+				<tbody>
+					{holdings.length === 0 && createdStockClasses.length === 0 && createdStakeholders.length === 0 ? (
+						<tr>
+							<td colSpan={5} style={{ textAlign: "center", opacity: 0.7, padding: "1.5rem", lineHeight: 1.5 }}>
+								<strong>No holdings yet.</strong><br /><br />
+								The table shows live onchain positions (via <code>getAveragePosition</code>) joined with the latest issuance records from Mongo.<br />
+								Recent direct onchain work appears here via optimistic state immediately, and becomes permanent once the poller has synced the events + rich metadata exists for the joins.
+							</td>
+						</tr>
+					) : null}
+
+					{holdings.map((h: any, idx: number) => (
+						<tr key={idx}>
+							<td>{h.stakeholder?.name?.legal_name || h.stakeholder?._id || "—"}</td>
+							<td>{h.stockClass?.name || h.stockClass?._id || "—"}</td>
+							<td style={{ fontFamily: "monospace" }}>{h.quantity}</td>
+							<td>{formatSharePrice(h.sharePrice)}</td>
+							<td>Onchain</td>
+						</tr>
+					))}
+
+					{/* Optimistic rows from direct onchain creations (user wallet signed) — only ones the poller hasn't materialized yet */}
+					{pendingIssuances.map((iss, i) => (
+						<tr key={`iss-${i}`} style={{ opacity: 0.75 }}>
+							<td>{iss.stakeholder_id}</td>
+							<td>{iss.stock_class_id}</td>
+							<td style={{ fontFamily: "monospace" }}>{iss.quantity} (pending)</td>
+							<td>{formatSharePrice(iss.share_price)}</td>
+							<td>
+								{iss.txHash ? (
+									<a 
+										href={`https://explorer.plume.org/tx/${iss.txHash}`} 
+										target="_blank" 
+										rel="noopener noreferrer"
+										style={{ color: "#16a34a", textDecoration: "underline" }}
+									>
+										Onchain ✓
+									</a>
+								) : "Pending sync"}
+							</td>
+						</tr>
+					))}
+
+					{/* Direct optimistic stock classes / stakeholders (for visibility in main table) */}
+					{createdStockClasses
+						.filter((sc: any) => sc.txHash)
+						.map((sc: any, i: number) => (
+							<tr key={`sc-opt-${i}`} style={{ opacity: 0.75, background: "#f8fafc" }}>
+								<td colSpan={2}>Stock Class: {sc.name}</td>
+								<td>—</td>
+								<td>—</td>
+								<td>
+									<a 
+										href={`https://explorer.plume.org/tx/${sc.txHash}`} 
+										target="_blank" 
+										rel="noopener noreferrer"
+										style={{ color: "#16a34a", textDecoration: "underline" }}
+									>
+										Onchain ✓
+									</a>
+								</td>
+							</tr>
+						))}
+
+					{createdStakeholders
+						.filter((sh: any) => sh.txHash)
+						.map((sh: any, i: number) => (
+							<tr key={`sh-opt-${i}`} style={{ opacity: 0.75, background: "#f8fafc" }}>
+								<td>Stakeholder: {(sh.name?.legal_name || sh.name) || sh._id}</td>
+								<td>—</td>
+								<td>—</td>
+								<td>—</td>
+								<td>
+									<a 
+										href={`https://explorer.plume.org/tx/${sh.txHash}`} 
+										target="_blank" 
+										rel="noopener noreferrer"
+										style={{ color: "#16a34a", textDecoration: "underline" }}
+									>
+										Onchain ✓
+									</a>
+								</td>
+							</tr>
+						))}
+				</tbody>
+			</StyledTable>
+			</TableScroll>
+
+			<MutedText>
+				Holdings come from <code>/cap-table/holdings/stock</code> (latest Mongo issuances + live
+				onchain <code>getAveragePosition</code> — only positive quantities are shown), merged with
+				optimistic direct creations from this session. Recent onchain activity may take a moment
+				to fully surface after the poller and metadata registration.
+			</MutedText>
+		</div>
+	);
+}

--- a/app/src/components/IssueStockForm.tsx
+++ b/app/src/components/IssueStockForm.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { FieldGroup, FieldRow, FieldLabel, SectionLabel, Input, Divider } from "./forms";
+import { MintButton } from "./buttons";
+import type { StockIssuanceData } from "../services/createStockIssuance";
+
+interface Option {
+	_id: string;
+	name?: string | { legal_name?: string };
+	label?: string;
+}
+
+interface Props {
+	stockClasses: Option[];
+	stakeholders: Option[];
+	onSubmit: (data: StockIssuanceData) => Promise<void>;
+	disabled?: boolean;
+}
+
+const defaultData: Omit<StockIssuanceData, "stakeholder_id" | "stock_class_id"> = {
+	quantity: "100000",
+	share_price: { currency: "USD", amount: "4.20" },
+	stock_legend_ids: [],
+	custom_id: "CS-A-001",
+	security_law_exemptions: [],
+	comments: ["Founder stock issuance"],
+};
+
+export function IssueStockForm({ stockClasses, stakeholders, onSubmit, disabled }: Props) {
+	const [stakeholderId, setStakeholderId] = useState("");
+	const [stockClassId, setStockClassId] = useState("");
+	const [data, setData] = useState(defaultData);
+	const [submitting, setSubmitting] = useState(false);
+
+	const updatePrice = (amount: string) => {
+		setData((d) => ({ ...d, share_price: { ...d.share_price, amount } }));
+	};
+
+	const handleSubmit = async () => {
+		if (!stakeholderId || !stockClassId) return;
+		setSubmitting(true);
+		try {
+			const full: StockIssuanceData = {
+				...data,
+				stakeholder_id: stakeholderId,
+				stock_class_id: stockClassId,
+			};
+			await onSubmit(full);
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	const isBusy = disabled || submitting;
+	const canSubmit = !!stakeholderId && !!stockClassId && !!data.quantity;
+
+	return (
+		<div>
+			<SectionLabel>Issue Stock</SectionLabel>
+
+			<FieldRow>
+				<FieldGroup>
+					<FieldLabel>Stakeholder</FieldLabel>
+					<select
+						value={stakeholderId}
+						onChange={(e) => setStakeholderId(e.target.value)}
+						disabled={isBusy}
+						style={{ padding: "0.5rem", fontFamily: "inherit", width: "100%" }}
+					>
+						<option value="">Select stakeholder...</option>
+						{stakeholders.map((s) => {
+							const name = typeof s.name === "object" && s.name ? (s.name as any).legal_name : s.name;
+							return (
+								<option key={s._id} value={s._id}>
+									{name || s.label || s._id}
+								</option>
+							);
+						})}
+					</select>
+				</FieldGroup>
+				<FieldGroup>
+					<FieldLabel>Stock Class</FieldLabel>
+					<select
+						value={stockClassId}
+						onChange={(e) => setStockClassId(e.target.value)}
+						disabled={isBusy}
+						style={{ padding: "0.5rem", fontFamily: "inherit", width: "100%" }}
+					>
+						<option value="">Select class...</option>
+						{stockClasses.map((c) => {
+							const name = typeof c.name === "object" && c.name ? (c.name as any) : c.name;
+							return (
+								<option key={c._id} value={c._id}>
+									{name || c.label || c._id}
+								</option>
+							);
+						})}
+					</select>
+				</FieldGroup>
+			</FieldRow>
+
+			<FieldRow>
+				<FieldGroup>
+					<FieldLabel>Quantity</FieldLabel>
+					<Input value={data.quantity} onChange={(e) => setData((d) => ({ ...d, quantity: e.target.value }))} disabled={isBusy} />
+				</FieldGroup>
+				<FieldGroup>
+					<FieldLabel>Price / Share (USD)</FieldLabel>
+					<Input value={data.share_price.amount} onChange={(e) => updatePrice(e.target.value)} disabled={isBusy} />
+				</FieldGroup>
+				<FieldGroup>
+					<FieldLabel>Custom ID</FieldLabel>
+					<Input value={data.custom_id || ""} onChange={(e) => setData((d) => ({ ...d, custom_id: e.target.value }))} disabled={isBusy} />
+				</FieldGroup>
+			</FieldRow>
+
+			<Divider />
+			<MintButton onClick={handleSubmit} disabled={isBusy || !canSubmit}>
+				{submitting ? "Issuing..." : "Issue Stock"}
+			</MintButton>
+		</div>
+	);
+}

--- a/app/src/components/IssuerHeader.tsx
+++ b/app/src/components/IssuerHeader.tsx
@@ -1,0 +1,70 @@
+import styled from "styled-components";
+import { DashboardHeader, SectionActions } from "./wrappers";
+import { InlineButton } from "./buttons";
+import type { IssuerResponse } from "../services/registerIssuer";
+
+const IssuerSummary = styled.div`
+	display: flex;
+	flex-flow: column nowrap;
+	gap: ${({ theme }) => theme.spacing.xs};
+	min-width: 0;
+`;
+
+const IssuerName = styled.div`
+	font-weight: ${({ theme }) => theme.fontWeights.semibold};
+	font-size: ${({ theme }) => theme.fontSizes.medium};
+`;
+
+const IssuerMeta = styled.div`
+	font-size: ${({ theme }) => theme.fontSizes.small};
+	opacity: 0.7;
+`;
+
+const MintedTag = styled.span`
+	display: inline-flex;
+	align-items: center;
+	padding: ${({ theme }) => theme.spacing.xs} ${({ theme }) => theme.spacing.sm};
+	background: ${({ theme }) => theme.colors.success};
+	color: ${({ theme }) => theme.colors.background};
+	font-size: ${({ theme }) => theme.fontSizes.small};
+	font-weight: ${({ theme }) => theme.fontWeights.semibold};
+	border-radius: ${({ theme }) => theme.radii.sm};
+`;
+
+interface IssuerHeaderProps {
+	issuer: IssuerResponse | null;
+	contractAddress: string | null;
+	onReset: () => void;
+}
+
+export function IssuerHeader({ issuer, contractAddress, onReset }: IssuerHeaderProps) {
+	if (!issuer) return null;
+
+	const explorerBase = "https://explorer.plume.org"; // TODO: make chain-aware later if needed
+
+	return (
+		<DashboardHeader>
+			<IssuerSummary>
+				<IssuerName>{issuer.legal_name}</IssuerName>
+				<IssuerMeta>
+					Issuer ID: <code>{issuer._id}</code>
+				</IssuerMeta>
+				{contractAddress && (
+					<IssuerMeta>
+						Contract:{" "}
+						<a href={`${explorerBase}/address/${contractAddress}`} target="_blank" rel="noopener noreferrer">
+							{contractAddress.slice(0, 10)}…{contractAddress.slice(-6)}
+						</a>
+					</IssuerMeta>
+				)}
+			</IssuerSummary>
+
+			<SectionActions>
+				<MintedTag>MINTED</MintedTag>
+				<InlineButton onClick={onReset} $variant="primary">
+					Mint Another
+				</InlineButton>
+			</SectionActions>
+		</DashboardHeader>
+	);
+}

--- a/app/src/components/MintNavDrawer.tsx
+++ b/app/src/components/MintNavDrawer.tsx
@@ -1,0 +1,206 @@
+import styled from "styled-components";
+import { useEffect } from "react";
+
+const Overlay = styled.div<{ $isOpen: boolean }>`
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.4);
+	opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
+	pointer-events: ${({ $isOpen }) => ($isOpen ? "auto" : "none")};
+	transition: opacity 0.2s ease;
+	z-index: 90;
+`;
+
+const Drawer = styled.div<{ $isOpen: boolean }>`
+	position: fixed;
+	top: 0;
+	right: 0;
+	height: 100vh;
+	width: min(320px, 85vw);
+	background: ${({ theme }) => theme.colors.background};
+	border-left: 1px solid ${({ theme }) => theme.colors.outline};
+	box-shadow: -4px 0 20px rgba(0, 0, 0, 0.15);
+	transform: translateX(${({ $isOpen }) => ($isOpen ? "0" : "100%")});
+	transition: transform 0.32s cubic-bezier(0.32, 0.72, 0, 1);
+	z-index: 100;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+`;
+
+const DrawerHeader = styled.div`
+	padding: 1rem 1.25rem;
+	border-bottom: 1px solid ${({ theme }) => theme.colors.outline};
+	font-weight: ${({ theme }) => theme.fontWeights.semibold};
+	font-size: ${({ theme }) => theme.fontSizes.medium};
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+`;
+
+const CloseButton = styled.button`
+	background: none;
+	border: none;
+	font-size: 1.25rem;
+	cursor: pointer;
+	line-height: 1;
+	color: ${({ theme }) => theme.colors.text};
+`;
+
+const NavSection = styled.div`
+	padding: 0.75rem 0;
+`;
+
+const NavLabel = styled.div`
+	font-size: ${({ theme }) => theme.fontSizes.small};
+	font-weight: ${({ theme }) => theme.fontWeights.semibold};
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	padding: 0.5rem 1.25rem;
+	color: ${({ theme }) => theme.colors.text};
+	opacity: 0.6;
+`;
+
+const NavItem = styled.button<{ $active?: boolean }>`
+	display: block;
+	width: 100%;
+	text-align: left;
+	padding: 0.55rem 1.25rem;
+	font-size: ${({ theme }) => theme.fontSizes.baseline};
+	background: ${({ $active, theme }) => ($active ? theme.colors.input : "transparent")};
+	border: none;
+	color: ${({ theme }) => theme.colors.text};
+	cursor: pointer;
+	transition: background 0.1s ease;
+
+	&:hover {
+		background: ${({ theme }) => theme.colors.input};
+	}
+`;
+
+const NavSubItem = styled(NavItem)`
+	padding-left: 2rem;
+	font-size: ${({ theme }) => theme.fontSizes.small};
+	opacity: 0.85;
+`;
+
+const DrawerFooter = styled.div`
+	margin-top: auto;
+	padding: 1rem 1.25rem;
+	border-top: 1px solid ${({ theme }) => theme.colors.outline};
+	font-size: ${({ theme }) => theme.fontSizes.small};
+	opacity: 0.6;
+`;
+
+export type MintView = "overview" | "stock-classes" | "stakeholders" | "activity";
+
+interface MintNavDrawerProps {
+	isOpen: boolean;
+	onClose: () => void;
+	currentView: MintView;
+	onNavigate: (view: MintView, id?: string) => void;
+
+	// Data from the session (things the user created)
+	stockClasses: Array<{ _id: string; name: string }>;
+	stakeholders: Array<{ _id: string; name: { legal_name?: string } }>;
+}
+
+export function MintNavDrawer({
+	isOpen,
+	onClose,
+	currentView,
+	onNavigate,
+	stockClasses,
+	stakeholders,
+}: MintNavDrawerProps) {
+	// Close on Escape key
+	useEffect(() => {
+		const handleKey = (e: KeyboardEvent) => {
+			if (e.key === "Escape" && isOpen) onClose();
+		};
+		window.addEventListener("keydown", handleKey);
+		return () => window.removeEventListener("keydown", handleKey);
+	}, [isOpen, onClose]);
+
+	const handleNav = (view: MintView, id?: string) => {
+		onNavigate(view, id);
+		onClose(); // close after navigation (nice mobile + desktop behavior)
+	};
+
+	return (
+		<>
+			<Overlay $isOpen={isOpen} onClick={onClose} />
+
+			<Drawer $isOpen={isOpen}>
+				<DrawerHeader>
+					<span>Cap Table Menu</span>
+					<CloseButton onClick={onClose} aria-label="Close menu">
+						×
+					</CloseButton>
+				</DrawerHeader>
+
+				<NavSection>
+					<NavLabel>Views</NavLabel>
+					<NavItem
+						$active={currentView === "overview"}
+						onClick={() => handleNav("overview")}
+					>
+						Overview &amp; Holdings
+					</NavItem>
+					<NavItem
+						$active={currentView === "stock-classes"}
+						onClick={() => handleNav("stock-classes")}
+					>
+						Stock Classes ({stockClasses.length})
+					</NavItem>
+					<NavItem
+						$active={currentView === "stakeholders"}
+						onClick={() => handleNav("stakeholders")}
+					>
+						Stakeholders
+					</NavItem>
+					<NavItem
+						$active={currentView === "activity"}
+						onClick={() => handleNav("activity")}
+					>
+						Activity &amp; Issuances
+					</NavItem>
+				</NavSection>
+
+				{stockClasses.length > 0 && (
+					<NavSection>
+						<NavLabel>Stock Classes</NavLabel>
+						{stockClasses.map((sc) => (
+							<NavSubItem
+								key={sc._id}
+								onClick={() => handleNav("stock-classes", sc._id)}
+							>
+								{sc.name}
+							</NavSubItem>
+						))}
+					</NavSection>
+				)}
+
+				{stakeholders.length > 0 && (
+					<NavSection>
+						<NavLabel>Stakeholders</NavLabel>
+						{stakeholders.map((sh) => (
+							<NavSubItem
+								key={sh._id}
+								onClick={() => handleNav("stakeholders", sh._id)}
+							>
+								{sh.name?.legal_name || sh._id}
+							</NavSubItem>
+						))}
+					</NavSection>
+				)}
+
+				<DrawerFooter>
+					These are the entities created in this mint session.
+					<br />
+					More features coming soon.
+				</DrawerFooter>
+			</Drawer>
+		</>
+	);
+}

--- a/app/src/components/Modal.tsx
+++ b/app/src/components/Modal.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect } from "react";
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+  maxWidth?: string;
+}
+
+export function Modal({ isOpen, onClose, title, children, maxWidth = "420px" }: ModalProps) {
+  // Close on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0, 0, 0, 0.55)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+        padding: "1rem",
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: "#fff",
+          borderRadius: "8px",
+          width: "100%",
+          maxWidth,
+          boxShadow: "0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)",
+          overflow: "hidden",
+        }}
+      >
+        {title && (
+          <div
+            style={{
+              padding: "14px 18px",
+              borderBottom: "1px solid #e5e7eb",
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              fontWeight: 600,
+              fontSize: "1rem",
+            }}
+          >
+            <span>{title}</span>
+            <button
+              onClick={onClose}
+              aria-label="Close modal"
+              style={{
+                background: "none",
+                border: "none",
+                fontSize: "22px",
+                lineHeight: 1,
+                cursor: "pointer",
+                color: "#6b7280",
+              }}
+            >
+              ×
+            </button>
+          </div>
+        )}
+
+        <div style={{ padding: "18px" }}>{children}</div>
+
+        {!title && (
+          <div style={{ padding: "0 18px 18px", textAlign: "right" }}>
+            <button
+              onClick={onClose}
+              style={{
+                background: "#0C0B0C",
+                color: "white",
+                border: "none",
+                padding: "8px 16px",
+                borderRadius: "4px",
+                cursor: "pointer",
+                fontSize: "0.875rem",
+              }}
+            >
+              Close
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/Navbar.tsx
+++ b/app/src/components/Navbar.tsx
@@ -1,7 +1,8 @@
 import styled from "styled-components";
 import dynamic from "next/dynamic";
-import { Nav } from "./wrappers";
-import { LogoRouter, StyledA, WalletButtonStyled } from "./buttons";
+import { Nav, NavBrand, NavTitle } from "./wrappers";
+import { InlineButton, LogoRouter, StyledA, WalletButtonStyled } from "./buttons";
+import { useCapTableMenu } from "./CapTableMenuContext";
 import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/router";
@@ -10,8 +11,17 @@ const NavActions = styled.span`
 	display: flex;
 	flex-flow: row nowrap;
 	align-items: center;
-	gap: 0.25rem;
+	gap: ${({ theme }) => theme.spacing.sm};
 `;
+
+// Route-derived titles are rendered in the navbar so individual pages
+// don't need to repeat the page heading in their body.
+const ROUTE_TITLES: Record<string, string> = {
+	"/": "Onchain cap tables.",
+	"/mint": "Mint Cap Table",
+	"/manage": "Manage Cap Tables",
+	"/manage/cap-table": "Cap Table Manager",
+};
 
 // Client-only: useAppKit requires createAppKit to have been called (client-side only)
 const WalletButton = dynamic(() => import("./WalletButtonClient"), {
@@ -21,23 +31,47 @@ const WalletButton = dynamic(() => import("./WalletButtonClient"), {
 
 export default function Navbar() {
 	const { pathname } = useRouter();
-	const showWallet = pathname === "/mint";
+	const { isEnabled: isMenuEnabled, setOpen: setMenuOpen } = useCapTableMenu();
+
+	// Mint/Manage links and the wallet button live in the navbar only while the
+	// user is actively on an app route. Docs and Github stay visible on every
+	// page so the landing page keeps the original outbound links.
+	const isAppRoute = pathname === "/mint" || pathname.startsWith("/manage");
+	const title = ROUTE_TITLES[pathname];
 
 	return (
 		<Nav>
-			<LogoRouter>
-				<Link href="/">
-					<Image src="/tap-logo.svg" alt="Transfer Agent Protocol" width={48} height={48} />
-				</Link>
-			</LogoRouter>
+			<NavBrand>
+				<LogoRouter>
+					<Link href="/">
+						<Image src="/tap-logo.svg" alt="Transfer Agent Protocol" width={48} height={48} />
+					</Link>
+				</LogoRouter>
+				{title && <NavTitle>{title}</NavTitle>}
+			</NavBrand>
 			<NavActions>
+				{isAppRoute && (
+					<>
+						<StyledA>
+							<Link href="/mint">Mint</Link>
+						</StyledA>
+						<StyledA>
+							<Link href="/manage">Manage</Link>
+						</StyledA>
+					</>
+				)}
 				<StyledA>
 					<Link href="https://docs.transferagentprotocol.xyz" target="_blank">Docs</Link>
 				</StyledA>
 				<StyledA>
 					<Link href="https://github.com/transfer-agent-protocol/tap-cap-table" target="_blank">Github</Link>
 				</StyledA>
-				{showWallet && <WalletButton />}
+				{isMenuEnabled && (
+					<InlineButton onClick={() => setMenuOpen(true)} $variant="primary" title="Open cap table navigation">
+						☰ Menu
+					</InlineButton>
+				)}
+				{isAppRoute && <WalletButton />}
 			</NavActions>
 		</Nav>
 	);

--- a/app/src/components/StakeholderForm.tsx
+++ b/app/src/components/StakeholderForm.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { FieldGroup, FieldRow, FieldLabel, SectionLabel, Input, Select, Divider } from "./forms";
+import { MintButton } from "./buttons";
+import type { StakeholderData } from "../services/createStakeholder";
+
+interface Props {
+	onSubmit: (data: StakeholderData) => Promise<void>;
+	disabled?: boolean;
+}
+
+const defaultData: StakeholderData = {
+	name: { legal_name: "Alex Palmer" },
+	stakeholder_type: "INDIVIDUAL",
+	current_relationship: "FOUNDER",
+	issuer_assigned_id: "",
+};
+
+export function StakeholderForm({ onSubmit, disabled }: Props) {
+	const [data, setData] = useState<StakeholderData>(defaultData);
+	const [submitting, setSubmitting] = useState(false);
+
+	const update = <K extends keyof StakeholderData>(key: K, value: StakeholderData[K]) => {
+		setData((d) => ({ ...d, [key]: value }));
+	};
+
+	const updateName = (legal_name: string) => {
+		setData((d) => ({ ...d, name: { ...d.name, legal_name } }));
+	};
+
+	const handleSubmit = async () => {
+		setSubmitting(true);
+		try {
+			await onSubmit(data);
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	const isBusy = disabled || submitting;
+
+	return (
+		<div>
+			<SectionLabel>Create Stakeholder</SectionLabel>
+			<FieldGroup>
+				<FieldLabel>Legal Name</FieldLabel>
+				<Input value={data.name.legal_name} onChange={(e) => updateName(e.target.value)} disabled={isBusy} />
+			</FieldGroup>
+
+			<FieldRow>
+				<FieldGroup>
+					<FieldLabel>Type</FieldLabel>
+					<Select
+						value={data.stakeholder_type}
+						onChange={(e) => update("stakeholder_type", e.target.value as "INDIVIDUAL" | "INSTITUTION")}
+						disabled={isBusy}
+					>
+						<option value="INDIVIDUAL">INDIVIDUAL</option>
+						<option value="INSTITUTION">INSTITUTION</option>
+					</Select>
+				</FieldGroup>
+				<FieldGroup>
+					<FieldLabel>Relationship</FieldLabel>
+					<Input value={data.current_relationship} onChange={(e) => update("current_relationship", e.target.value)} disabled={isBusy} />
+				</FieldGroup>
+			</FieldRow>
+
+			<Divider />
+			<MintButton onClick={handleSubmit} disabled={isBusy || !data.name.legal_name}>
+				{submitting ? "Creating..." : "Create Stakeholder"}
+			</MintButton>
+		</div>
+	);
+}

--- a/app/src/components/StockClassForm.tsx
+++ b/app/src/components/StockClassForm.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { FieldGroup, FieldRow, FieldLabel, SectionLabel, Input, Select, Divider } from "./forms";
+import { MintButton } from "./buttons";
+import type { StockClassData } from "../services/createStockClass";
+
+interface Props {
+	onSubmit: (data: StockClassData) => Promise<void>;
+	disabled?: boolean;
+}
+
+const defaultData: StockClassData = {
+	name: "Series A Common",
+	class_type: "COMMON",
+	default_id_prefix: "CS-A",
+	initial_shares_authorized: "1000000",
+	votes_per_share: "1",
+	price_per_share: { currency: "USD", amount: "4.20" },
+	seniority: "1",
+};
+
+export function StockClassForm({ onSubmit, disabled }: Props) {
+	const [data, setData] = useState<StockClassData>(defaultData);
+	const [submitting, setSubmitting] = useState(false);
+
+	const isBusy = disabled || submitting;
+
+	const update = <K extends keyof StockClassData>(key: K, value: StockClassData[K]) => {
+		setData((d) => ({ ...d, [key]: value }));
+	};
+
+	const updatePrice = (amount: string) => {
+		setData((d) => ({ ...d, price_per_share: { ...d.price_per_share, amount } }));
+	};
+
+	const handleSubmit = async () => {
+		setSubmitting(true);
+		try {
+			await onSubmit(data);
+			// keep values for quick successive creates (or reset if preferred)
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	return (
+		<div>
+			<SectionLabel>Create Stock Class</SectionLabel>
+			<FieldGroup>
+				<FieldLabel>Name</FieldLabel>
+				<Input value={data.name} onChange={(e) => update("name", e.target.value)} disabled={isBusy} />
+			</FieldGroup>
+
+			<FieldRow>
+				<FieldGroup>
+					<FieldLabel>Type</FieldLabel>
+					<Select
+						value={data.class_type}
+						onChange={(e) => update("class_type", e.target.value as "COMMON" | "PREFERRED")}
+						disabled={isBusy}
+					>
+						<option value="COMMON">COMMON</option>
+						<option value="PREFERRED">PREFERRED</option>
+					</Select>
+				</FieldGroup>
+				<FieldGroup>
+					<FieldLabel>ID Prefix</FieldLabel>
+					<Input value={data.default_id_prefix} onChange={(e) => update("default_id_prefix", e.target.value)} disabled={isBusy} />
+				</FieldGroup>
+			</FieldRow>
+
+			<FieldRow>
+				<FieldGroup>
+					<FieldLabel>Shares Authorized</FieldLabel>
+					<Input value={data.initial_shares_authorized} onChange={(e) => update("initial_shares_authorized", e.target.value)} disabled={isBusy} />
+				</FieldGroup>
+				<FieldGroup>
+					<FieldLabel>Votes / Share</FieldLabel>
+					<Input value={data.votes_per_share} onChange={(e) => update("votes_per_share", e.target.value)} disabled={isBusy} />
+				</FieldGroup>
+				<FieldGroup>
+					<FieldLabel>Seniority</FieldLabel>
+					<Input value={data.seniority} onChange={(e) => update("seniority", e.target.value)} disabled={isBusy} />
+				</FieldGroup>
+			</FieldRow>
+
+			<FieldRow>
+				<FieldGroup>
+					<FieldLabel>Price per Share (USD)</FieldLabel>
+					<Input value={data.price_per_share.amount} onChange={(e) => updatePrice(e.target.value)} disabled={isBusy} />
+				</FieldGroup>
+			</FieldRow>
+
+			<Divider />
+			<MintButton onClick={handleSubmit} disabled={isBusy || !data.name || !data.initial_shares_authorized}>
+				{submitting ? "Creating..." : "Create Stock Class"}
+			</MintButton>
+		</div>
+	);
+}

--- a/app/src/components/TxSuccessModal.tsx
+++ b/app/src/components/TxSuccessModal.tsx
@@ -1,0 +1,81 @@
+import { Modal } from "./Modal";
+
+interface TxSuccessModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  txHash?: string;
+  message?: string;
+}
+
+export function TxSuccessModal({ isOpen, onClose, title, txHash, message }: TxSuccessModalProps) {
+  const explorerUrl = txHash ? `https://explorer.plume.org/tx/${txHash}` : undefined;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={title}>
+      <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+        {message && <p style={{ margin: 0, color: "#374151" }}>{message}</p>}
+
+        {txHash ? (
+          <div>
+            <div style={{ fontSize: "0.8rem", color: "#6b7280", marginBottom: "4px" }}>
+              Transaction Hash
+            </div>
+            <div
+              style={{
+                fontFamily: "monospace",
+                fontSize: "0.85rem",
+                wordBreak: "break-all",
+                background: "#f3f4f6",
+                padding: "8px 10px",
+                borderRadius: "4px",
+                marginBottom: "12px",
+              }}
+            >
+              {txHash}
+            </div>
+
+            {explorerUrl && (
+              <a
+                href={explorerUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  display: "inline-block",
+                  background: "#0C0B0C",
+                  color: "white",
+                  padding: "8px 14px",
+                  borderRadius: "4px",
+                  textDecoration: "none",
+                  fontSize: "0.875rem",
+                }}
+              >
+                View on Plume Explorer →
+              </a>
+            )}
+          </div>
+        ) : (
+          <p style={{ color: "#6b7280", fontSize: "0.9rem" }}>
+            Transaction submitted. Check your wallet for confirmation.
+          </p>
+        )}
+
+        <div style={{ marginTop: "8px", textAlign: "right" }}>
+          <button
+            onClick={onClose}
+            style={{
+              background: "transparent",
+              border: "1px solid #d1d5db",
+              padding: "8px 16px",
+              borderRadius: "4px",
+              cursor: "pointer",
+              fontSize: "0.875rem",
+            }}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/app/src/components/buttons.tsx
+++ b/app/src/components/buttons.tsx
@@ -119,4 +119,34 @@ const MintButton = styled.button`
 	}
 `;
 
-export { LogoRouter, StyledA, PrimaryButton, WalletButtonStyled, MintButton }
+const InlineButton = styled.button<{ $variant?: "primary" | "secondary" | "danger" }>`
+	display: inline-flex;
+	flex-flow: row nowrap;
+	align-items: center;
+	justify-content: center;
+	min-height: 2rem;
+	padding: 0 ${({ theme }) => theme.spacing.md};
+	border: 1px solid
+		${({ theme, $variant }) => ($variant === "danger" ? theme.colors.error : theme.colors.main)};
+	border-radius: ${({ theme }) => theme.radii.sm};
+	background: ${({ theme, $variant }) => ($variant === "primary" ? theme.colors.main : "transparent")};
+	color: ${({ theme, $variant }) =>
+		$variant === "primary" ? theme.colors.background : $variant === "danger" ? theme.colors.error : theme.colors.text};
+	font-family: inherit;
+	font-size: ${({ theme }) => theme.fontSizes.small};
+	font-weight: ${({ theme }) => theme.fontWeights.bold};
+	cursor: pointer;
+	transition: opacity 0.168s cubic-bezier(0.211, 0.69, 0.313, 1);
+	white-space: nowrap;
+
+	&:hover:not(:disabled) {
+		opacity: 0.85;
+	}
+
+	&:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+`;
+
+export { LogoRouter, StyledA, PrimaryButton, WalletButtonStyled, MintButton, InlineButton }

--- a/app/src/components/forms.tsx
+++ b/app/src/components/forms.tsx
@@ -46,7 +46,6 @@ const FormInput = styled.input`
 
     &:hover {
         outline: 1px solid ${({ theme }) => theme.colors.accent};
-		box-shadow: 0 0 0 1px ${({ theme }) => theme.colors.accent};
     }
 
     @media only screen and (max-width: 768px) {
@@ -157,6 +156,28 @@ const Input = styled.input`
 	}
 `;
 
+const Select = styled.select`
+	width: 100%;
+	padding: 0.75rem;
+	font-size: ${({ theme }) => theme.fontSizes.baseline};
+	font-family: inherit;
+	background: ${({ theme }) => theme.colors.background};
+	border: 1px solid ${({ theme }) => theme.colors.outline};
+	border-radius: ${({ theme }) => theme.borderRadius.main};
+	color: ${({ theme }) => theme.colors.text};
+	box-sizing: border-box;
+
+	&:focus {
+		outline: 2px solid ${({ theme }) => theme.colors.main};
+		outline-offset: 1px;
+	}
+
+	&:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+`;
+
 const Divider = styled.hr`
 	width: 100%;
 	border: none;
@@ -164,4 +185,4 @@ const Divider = styled.hr`
 	margin: 0.5rem 0;
 `;
 
-export { FormWrapper, FormInput, FormTextArea, FormValidation, FieldGroup, FieldRow, FieldLabel, SectionLabel, Input, Divider };
+export { FormWrapper, FormInput, FormTextArea, FormValidation, FieldGroup, FieldRow, FieldLabel, SectionLabel, Input, Select, Divider }

--- a/app/src/components/layout.tsx
+++ b/app/src/components/layout.tsx
@@ -1,15 +1,24 @@
+import { useRouter } from "next/router";
 import Navbar from "./Navbar";
-import { FooterContent, FooterWrapper, FullWidth, Main } from "./wrappers";
+import { FooterContent, FooterWrapper, FullWidth, Main, FullScreenMain } from "./wrappers";
 interface Props {
 	children: React.ReactNode;
 	className?: string;
 }
 
 export default function Layout({ children }: Props) {
+	const { pathname } = useRouter();
+	const isMintPage = pathname === "/mint";
+	const isManagePage = pathname === "/manage" || pathname.startsWith("/manage/");
+
 	return (
 		<FullWidth>
 			<Navbar />
-			<Main>{children}</Main>
+			{isMintPage || isManagePage ? (
+				<FullScreenMain>{children}</FullScreenMain>
+			) : (
+				<Main>{children}</Main>
+			)}
 			<FooterWrapper>
 				<FooterContent>
 					© {new Date().getFullYear()}

--- a/app/src/components/theme.tsx
+++ b/app/src/components/theme.tsx
@@ -34,6 +34,52 @@ const theme: DefaultTheme = {
 		none: "0",
 		main: "0.131rem",
 	},
+	spacing: {
+		0: "0",
+		xs: "0.25rem",
+		sm: "0.5rem",
+		md: "1rem",
+		lg: "1.5rem",
+		xl: "2rem",
+		"2xl": "3rem",
+		"3xl": "4rem",
+	},
+	fontWeights: {
+		normal: 400,
+		medium: 500,
+		semibold: 600,
+		bold: 700,
+	},
+	breakpoints: {
+		sm: "475px",
+		mobile: "512px",
+		tablet: "768px",
+		mintCollapse: "900px",
+	},
+	radii: {
+		none: "0",
+		main: "0.131rem",
+		sm: "4px",
+		md: "0.5rem",
+	},
+	shadows: {
+		sm: "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
+		focus: "0 0 0 2px #0C0B0C",
+	},
+	transitions: {
+		default: "all 0.168s cubic-bezier(0.211, 0.69, 0.313, 1)",
+		spring: "0.3s cubic-bezier(0.68, -0.55, 0.27, 1.55)",
+	},
+	maxWidths: {
+		main: "768px",
+		article: "46rem",
+		h1: "52rem",
+	},
+	zIndices: {
+		base: 1,
+		dropdown: 10,
+		modal: 100,
+	},
 };
 
 export default theme;

--- a/app/src/components/wrappers.tsx
+++ b/app/src/components/wrappers.tsx
@@ -9,13 +9,48 @@ const FullWidth = styled.div`
 `;
 
 const Nav = styled.nav`
-    display: flex;
-    flex-flow: row nowrap;
-    justify-content: space-between;
+	position: sticky;
+	top: 0;
+	z-index: ${({ theme }) => theme.zIndices.dropdown};
+	display: flex;
+	flex-flow: row nowrap;
+	justify-content: space-between;
 	align-items: center;
+	gap: ${({ theme }) => theme.spacing.md};
 	width: 100%;
 	max-width: 100%;
-	padding: 1rem 0;
+	padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.xl};
+	box-sizing: border-box;
+	background: ${({ theme }) => theme.colors.background};
+	border-bottom: 1px solid ${({ theme }) => theme.colors.outline};
+
+	@media only screen and (max-width: ${({ theme }) => theme.breakpoints.tablet}) {
+		padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md};
+	}
+`;
+
+const NavBrand = styled.div`
+	display: flex;
+	flex-flow: row nowrap;
+	align-items: center;
+	gap: ${({ theme }) => theme.spacing.md};
+	min-width: 0;
+`;
+
+const NavTitle = styled.h1`
+	margin: 0;
+	color: ${({ theme }) => theme.colors.text};
+	font-size: ${({ theme }) => theme.fontSizes.medium};
+	font-weight: ${({ theme }) => theme.fontWeights.bold};
+	line-height: ${({ theme }) => theme.lineHeights.H2};
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+
+	@media only screen and (max-width: ${({ theme }) => theme.breakpoints.mobile}) {
+		font-size: ${({ theme }) => theme.fontSizes.baseline};
+		white-space: normal;
+	}
 `;
 
 const Logotype = styled.span`
@@ -135,13 +170,13 @@ const Credits = styled.div`
 const StyledTable = styled.table`
   width: 100%;
   border-collapse: collapse;
-  margin: 1rem 0;
+  margin: ${({ theme }) => theme.spacing.md} 0;
   font-size: ${({ theme }) => theme.fontSizes.baseline};
   table-layout: fixed; /* Helps to apply word wrapping */
 
   th, td {
     text-align: left;
-    padding: 0.5rem;
+    padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md};
     border-bottom: 1px solid ${({ theme }) => theme.colors.main};
     word-break: break-word; /* Ensures text wraps inside the cell */
   }
@@ -283,4 +318,117 @@ const ResponseBlock = styled.pre`
 	margin: 0;
 `;
 
-export { FullWidth, Nav, Logotype, Main, Heading, Content, Article, Credits, StyledTable, FooterWrapper, FooterContent, FooterAside, MintLayout, Panel, StatusBox, ResponseBlock };
+/* Full-screen / dashboard primitives for the updated /mint experience (additive only) */
+const FullScreenMain = styled.div`
+	display: flex;
+	flex-flow: column nowrap;
+	width: 100%;
+	min-height: 70vh;
+	padding: ${({ theme }) => theme.spacing.lg} ${({ theme }) => theme.spacing.xl};
+	box-sizing: border-box;
+
+	@media (max-width: ${({ theme }) => theme.breakpoints.tablet}) {
+		padding: ${({ theme }) => theme.spacing.md};
+	}
+`;
+
+const FullScreenStack = styled.div`
+	display: flex;
+	flex-flow: column nowrap;
+	gap: ${({ theme }) => theme.spacing.lg};
+	width: 100%;
+`;
+
+const PageIntro = styled.section`
+	display: flex;
+	flex-flow: column nowrap;
+	align-items: flex-start;
+	gap: ${({ theme }) => theme.spacing.sm};
+	max-width: ${({ theme }) => theme.maxWidths.h1};
+
+	p {
+		margin-bottom: 0;
+	}
+`;
+
+const ActionTableLayout = styled.div`
+	display: grid;
+	grid-template-columns: minmax(18rem, 24rem) minmax(0, 1fr);
+	gap: ${({ theme }) => theme.spacing.xl};
+	align-items: flex-start;
+	width: 100%;
+
+	@media (max-width: ${({ theme }) => theme.breakpoints.mintCollapse}) {
+		grid-template-columns: 1fr;
+	}
+`;
+const DashboardHeader = styled.header`
+	display: flex;
+	flex-flow: row wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: ${({ theme }) => theme.spacing.md};
+	margin-bottom: ${({ theme }) => theme.spacing.lg};
+	padding-bottom: ${({ theme }) => theme.spacing.md};
+	border-bottom: 1px solid ${({ theme }) => theme.colors.outline};
+`;
+
+const DashboardGrid = styled.div`
+	display: grid;
+	grid-template-columns: 1fr 2fr;
+	gap: ${({ theme }) => theme.spacing.xl};
+
+	@media (max-width: ${({ theme }) => theme.breakpoints.mintCollapse}) {
+		grid-template-columns: 1fr;
+	}
+`;
+
+const FormPanel = styled.div`
+	display: flex;
+	flex-flow: column nowrap;
+	gap: ${({ theme }) => theme.spacing.md};
+	min-width: 0;
+`;
+
+const TablePanel = styled.div`
+	display: flex;
+	flex-flow: column nowrap;
+	gap: ${({ theme }) => theme.spacing.md};
+	min-width: 0;
+`;
+
+const TableTitle = styled.h3`
+	font-size: ${({ theme }) => theme.fontSizes.baseline};
+	font-weight: ${({ theme }) => theme.fontWeights.semibold};
+	margin: 0 0 ${({ theme }) => theme.spacing.sm} 0;
+`;
+const SectionHeader = styled.div`
+	display: flex;
+	flex-flow: row wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: ${({ theme }) => theme.spacing.sm};
+	width: 100%;
+`;
+
+const SectionActions = styled.div`
+	display: flex;
+	flex-flow: row wrap;
+	align-items: center;
+	justify-content: flex-end;
+	gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+const TableScroll = styled.div`
+	width: 100%;
+	overflow-x: auto;
+`;
+
+const MutedText = styled.p`
+	margin: 0;
+	font-size: ${({ theme }) => theme.fontSizes.small};
+	line-height: 1.4;
+	opacity: 0.65;
+`;
+
+export { FullWidth, Nav, NavBrand, NavTitle, Logotype, Main, Heading, Content, Article, Credits, StyledTable, FooterWrapper, FooterContent, FooterAside, MintLayout, Panel, StatusBox, ResponseBlock, FullScreenMain, FullScreenStack, PageIntro, ActionTableLayout, DashboardHeader, DashboardGrid, FormPanel, TablePanel, TableTitle, SectionHeader, SectionActions, TableScroll, MutedText };

--- a/app/src/generated.ts
+++ b/app/src/generated.ts
@@ -1,6 +1,776 @@
 import { createUseReadContract, createUseWriteContract, createUseSimulateContract, createUseWatchContractEvent } from "wagmi/codegen";
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// CapTable
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const capTableAbi = [
+    { type: "constructor", inputs: [], stateMutability: "nonpayable" },
+    { type: "function", inputs: [], name: "ADMIN_ROLE", outputs: [{ name: "", internalType: "bytes32", type: "bytes32" }], stateMutability: "view" },
+    {
+        type: "function",
+        inputs: [],
+        name: "DEFAULT_ADMIN_ROLE",
+        outputs: [{ name: "", internalType: "bytes32", type: "bytes32" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [],
+        name: "OPERATOR_ROLE",
+        outputs: [{ name: "", internalType: "bytes32", type: "bytes32" }],
+        stateMutability: "view",
+    },
+    { type: "function", inputs: [], name: "acceptDefaultAdminTransfer", outputs: [], stateMutability: "nonpayable" },
+    {
+        type: "function",
+        inputs: [
+            { name: "stakeholderId", internalType: "bytes16", type: "bytes16" },
+            { name: "stockClassId", internalType: "bytes16", type: "bytes16" },
+            { name: "securityId", internalType: "bytes16", type: "bytes16" },
+            { name: "comments", internalType: "string[]", type: "string[]" },
+        ],
+        name: "acceptStock",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "addr", internalType: "address", type: "address" }],
+        name: "addAdmin",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "addr", internalType: "address", type: "address" }],
+        name: "addOperator",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [
+            { name: "_stakeholder_id", internalType: "bytes16", type: "bytes16" },
+            { name: "_wallet", internalType: "address", type: "address" },
+        ],
+        name: "addWalletToStakeholder",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [
+            { name: "newSharesAuthorized", internalType: "uint256", type: "uint256" },
+            { name: "comments", internalType: "string[]", type: "string[]" },
+            { name: "boardApprovalDate", internalType: "string", type: "string" },
+            { name: "stockholderApprovalDate", internalType: "string", type: "string" },
+        ],
+        name: "adjustIssuerAuthorizedShares",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [
+            { name: "stockClassId", internalType: "bytes16", type: "bytes16" },
+            { name: "newAuthorizedShares", internalType: "uint256", type: "uint256" },
+            { name: "comments", internalType: "string[]", type: "string[]" },
+            { name: "boardApprovalDate", internalType: "string", type: "string" },
+            { name: "stockholderApprovalDate", internalType: "string", type: "string" },
+        ],
+        name: "adjustStockClassAuthorizedShares",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "newAdmin", internalType: "address", type: "address" }],
+        name: "beginDefaultAdminTransfer",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    { type: "function", inputs: [], name: "cancelDefaultAdminTransfer", outputs: [], stateMutability: "nonpayable" },
+    {
+        type: "function",
+        inputs: [
+            {
+                name: "params",
+                internalType: "struct StockParams",
+                type: "tuple",
+                components: [
+                    { name: "stakeholder_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "stock_class_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "security_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "comments", internalType: "string[]", type: "string[]" },
+                    { name: "reason_text", internalType: "string", type: "string" },
+                ],
+            },
+            { name: "quantity", internalType: "uint256", type: "uint256" },
+        ],
+        name: "cancelStock",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "newDelay", internalType: "uint48", type: "uint48" }],
+        name: "changeDefaultAdminDelay",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [
+            { name: "_id", internalType: "bytes16", type: "bytes16" },
+            { name: "_stakeholder_type", internalType: "string", type: "string" },
+            { name: "_current_relationship", internalType: "string", type: "string" },
+        ],
+        name: "createStakeholder",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [
+            { name: "_id", internalType: "bytes16", type: "bytes16" },
+            { name: "_class_type", internalType: "string", type: "string" },
+            { name: "_price_per_share", internalType: "uint256", type: "uint256" },
+            { name: "_initial_share_authorized", internalType: "uint256", type: "uint256" },
+        ],
+        name: "createStockClass",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "_id", internalType: "bytes16", type: "bytes16" }],
+        name: "createStockLegendTemplate",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [],
+        name: "defaultAdmin",
+        outputs: [{ name: "", internalType: "address", type: "address" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [],
+        name: "defaultAdminDelay",
+        outputs: [{ name: "", internalType: "uint48", type: "uint48" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [],
+        name: "defaultAdminDelayIncreaseWait",
+        outputs: [{ name: "", internalType: "uint48", type: "uint48" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [
+            { name: "stakeholderId", internalType: "bytes16", type: "bytes16" },
+            { name: "securityId", internalType: "bytes16", type: "bytes16" },
+        ],
+        name: "getActivePosition",
+        outputs: [
+            { name: "", internalType: "bytes16", type: "bytes16" },
+            { name: "", internalType: "uint256", type: "uint256" },
+            { name: "", internalType: "uint256", type: "uint256" },
+            { name: "", internalType: "uint40", type: "uint40" },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [
+            { name: "stakeholderId", internalType: "bytes16", type: "bytes16" },
+            { name: "stockClassId", internalType: "bytes16", type: "bytes16" },
+        ],
+        name: "getAveragePosition",
+        outputs: [
+            { name: "", internalType: "uint256", type: "uint256" },
+            { name: "", internalType: "uint256", type: "uint256" },
+            { name: "", internalType: "uint40", type: "uint40" },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "role", internalType: "bytes32", type: "bytes32" }],
+        name: "getRoleAdmin",
+        outputs: [{ name: "", internalType: "bytes32", type: "bytes32" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "_id", internalType: "bytes16", type: "bytes16" }],
+        name: "getStakeholderById",
+        outputs: [
+            { name: "", internalType: "bytes16", type: "bytes16" },
+            { name: "", internalType: "string", type: "string" },
+            { name: "", internalType: "string", type: "string" },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "_wallet", internalType: "address", type: "address" }],
+        name: "getStakeholderIdByWallet",
+        outputs: [{ name: "stakeholderId", internalType: "bytes16", type: "bytes16" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "_id", internalType: "bytes16", type: "bytes16" }],
+        name: "getStockClassById",
+        outputs: [
+            { name: "", internalType: "bytes16", type: "bytes16" },
+            { name: "", internalType: "string", type: "string" },
+            { name: "", internalType: "uint256", type: "uint256" },
+            { name: "", internalType: "uint256", type: "uint256" },
+            { name: "", internalType: "uint256", type: "uint256" },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [],
+        name: "getTotalActiveSecuritiesCount",
+        outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [],
+        name: "getTotalNumberOfStakeholders",
+        outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [],
+        name: "getTotalNumberOfStockClasses",
+        outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [],
+        name: "getTransactionsCount",
+        outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [
+            { name: "role", internalType: "bytes32", type: "bytes32" },
+            { name: "account", internalType: "address", type: "address" },
+        ],
+        name: "grantRole",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [
+            { name: "role", internalType: "bytes32", type: "bytes32" },
+            { name: "account", internalType: "address", type: "address" },
+        ],
+        name: "hasRole",
+        outputs: [{ name: "", internalType: "bool", type: "bool" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [
+            { name: "id", internalType: "bytes16", type: "bytes16" },
+            { name: "name", internalType: "string", type: "string" },
+            { name: "initial_shares_authorized", internalType: "uint256", type: "uint256" },
+            { name: "admin", internalType: "address", type: "address" },
+            { name: "operator", internalType: "address", type: "address" },
+        ],
+        name: "initialize",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [
+            {
+                name: "params",
+                internalType: "struct StockIssuanceParams",
+                type: "tuple",
+                components: [
+                    { name: "stock_class_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "stock_plan_id", internalType: "bytes16", type: "bytes16" },
+                    {
+                        name: "share_numbers_issued",
+                        internalType: "struct ShareNumbersIssued",
+                        type: "tuple",
+                        components: [
+                            { name: "starting_share_number", internalType: "uint256", type: "uint256" },
+                            { name: "ending_share_number", internalType: "uint256", type: "uint256" },
+                        ],
+                    },
+                    { name: "share_price", internalType: "uint256", type: "uint256" },
+                    { name: "quantity", internalType: "uint256", type: "uint256" },
+                    { name: "vesting_terms_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "cost_basis", internalType: "uint256", type: "uint256" },
+                    { name: "stock_legend_ids", internalType: "bytes16[]", type: "bytes16[]" },
+                    { name: "issuance_type", internalType: "string", type: "string" },
+                    { name: "comments", internalType: "string[]", type: "string[]" },
+                    { name: "custom_id", internalType: "string", type: "string" },
+                    { name: "stakeholder_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "board_approval_date", internalType: "string", type: "string" },
+                    { name: "stockholder_approval_date", internalType: "string", type: "string" },
+                    { name: "consideration_text", internalType: "string", type: "string" },
+                    { name: "security_law_exemptions", internalType: "string[]", type: "string[]" },
+                ],
+            },
+        ],
+        name: "issueStock",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [],
+        name: "issuer",
+        outputs: [
+            { name: "id", internalType: "bytes16", type: "bytes16" },
+            { name: "legal_name", internalType: "string", type: "string" },
+            { name: "shares_issued", internalType: "uint256", type: "uint256" },
+            { name: "shares_authorized", internalType: "uint256", type: "uint256" },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [
+            { name: "stakeholderIds", internalType: "bytes16[]", type: "bytes16[]" },
+            { name: "securityIds", internalType: "bytes16[]", type: "bytes16[]" },
+            { name: "stockClassIds", internalType: "bytes16[]", type: "bytes16[]" },
+            { name: "quantities", internalType: "uint256[]", type: "uint256[]" },
+            { name: "sharePrices", internalType: "uint256[]", type: "uint256[]" },
+            { name: "timestamps", internalType: "uint40[]", type: "uint40[]" },
+        ],
+        name: "mintActivePositions",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [
+            {
+                name: "params",
+                internalType: "struct InitialShares",
+                type: "tuple",
+                components: [
+                    {
+                        name: "issuerInitialShares",
+                        internalType: "struct IssuerInitialShares",
+                        type: "tuple",
+                        components: [
+                            { name: "shares_authorized", internalType: "uint256", type: "uint256" },
+                            { name: "shares_issued", internalType: "uint256", type: "uint256" },
+                        ],
+                    },
+                    {
+                        name: "stockClassesInitialShares",
+                        internalType: "struct StockClassInitialShares[]",
+                        type: "tuple[]",
+                        components: [
+                            { name: "id", internalType: "bytes16", type: "bytes16" },
+                            { name: "shares_authorized", internalType: "uint256", type: "uint256" },
+                            { name: "shares_issued", internalType: "uint256", type: "uint256" },
+                        ],
+                    },
+                ],
+            },
+        ],
+        name: "mintSharesAuthorized",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    { type: "function", inputs: [], name: "nonce", outputs: [{ name: "", internalType: "uint256", type: "uint256" }], stateMutability: "view" },
+    { type: "function", inputs: [], name: "owner", outputs: [{ name: "", internalType: "address", type: "address" }], stateMutability: "view" },
+    {
+        type: "function",
+        inputs: [],
+        name: "pendingDefaultAdmin",
+        outputs: [
+            { name: "newAdmin", internalType: "address", type: "address" },
+            { name: "schedule", internalType: "uint48", type: "uint48" },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [],
+        name: "pendingDefaultAdminDelay",
+        outputs: [
+            { name: "newDelay", internalType: "uint48", type: "uint48" },
+            { name: "schedule", internalType: "uint48", type: "uint48" },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [
+            {
+                name: "params",
+                internalType: "struct StockParams",
+                type: "tuple",
+                components: [
+                    { name: "stakeholder_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "stock_class_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "security_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "comments", internalType: "string[]", type: "string[]" },
+                    { name: "reason_text", internalType: "string", type: "string" },
+                ],
+            },
+            { name: "resulting_security_ids", internalType: "bytes16[]", type: "bytes16[]" },
+        ],
+        name: "reissueStock",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "addr", internalType: "address", type: "address" }],
+        name: "removeAdmin",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "addr", internalType: "address", type: "address" }],
+        name: "removeOperator",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [
+            { name: "_stakeholder_id", internalType: "bytes16", type: "bytes16" },
+            { name: "_wallet", internalType: "address", type: "address" },
+        ],
+        name: "removeWalletFromStakeholder",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [
+            { name: "role", internalType: "bytes32", type: "bytes32" },
+            { name: "account", internalType: "address", type: "address" },
+        ],
+        name: "renounceRole",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [
+            {
+                name: "params",
+                internalType: "struct StockParams",
+                type: "tuple",
+                components: [
+                    { name: "stakeholder_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "stock_class_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "security_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "comments", internalType: "string[]", type: "string[]" },
+                    { name: "reason_text", internalType: "string", type: "string" },
+                ],
+            },
+            { name: "quantity", internalType: "uint256", type: "uint256" },
+            { name: "price", internalType: "uint256", type: "uint256" },
+        ],
+        name: "repurchaseStock",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [
+            {
+                name: "params",
+                internalType: "struct StockParams",
+                type: "tuple",
+                components: [
+                    { name: "stakeholder_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "stock_class_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "security_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "comments", internalType: "string[]", type: "string[]" },
+                    { name: "reason_text", internalType: "string", type: "string" },
+                ],
+            },
+        ],
+        name: "retractStockIssuance",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [
+            { name: "role", internalType: "bytes32", type: "bytes32" },
+            { name: "account", internalType: "address", type: "address" },
+        ],
+        name: "revokeRole",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    { type: "function", inputs: [], name: "rollbackDefaultAdminDelay", outputs: [], stateMutability: "nonpayable" },
+    {
+        type: "function",
+        inputs: [{ name: "", internalType: "bytes16", type: "bytes16" }],
+        name: "stakeholderIndex",
+        outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+        name: "stakeholders",
+        outputs: [
+            { name: "id", internalType: "bytes16", type: "bytes16" },
+            { name: "stakeholder_type", internalType: "string", type: "string" },
+            { name: "current_relationship", internalType: "string", type: "string" },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "", internalType: "bytes16", type: "bytes16" }],
+        name: "stockClassIndex",
+        outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+        name: "stockClasses",
+        outputs: [
+            { name: "id", internalType: "bytes16", type: "bytes16" },
+            { name: "class_type", internalType: "string", type: "string" },
+            { name: "price_per_share", internalType: "uint256", type: "uint256" },
+            { name: "shares_issued", internalType: "uint256", type: "uint256" },
+            { name: "shares_authorized", internalType: "uint256", type: "uint256" },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+        name: "stockLegendTemplates",
+        outputs: [{ name: "id", internalType: "bytes16", type: "bytes16" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "interfaceId", internalType: "bytes4", type: "bytes4" }],
+        name: "supportsInterface",
+        outputs: [{ name: "", internalType: "bool", type: "bool" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+        name: "transactions",
+        outputs: [{ name: "", internalType: "bytes", type: "bytes" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        inputs: [
+            {
+                name: "params",
+                internalType: "struct StockTransferParams",
+                type: "tuple",
+                components: [
+                    { name: "transferor_stakeholder_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "transferee_stakeholder_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "stock_class_id", internalType: "bytes16", type: "bytes16" },
+                    { name: "is_buyer_verified", internalType: "bool", type: "bool" },
+                    { name: "quantity", internalType: "uint256", type: "uint256" },
+                    { name: "share_price", internalType: "uint256", type: "uint256" },
+                    { name: "nonce", internalType: "uint256", type: "uint256" },
+                    { name: "custom_id", internalType: "string", type: "string" },
+                ],
+            },
+        ],
+        name: "transferStock",
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        inputs: [{ name: "", internalType: "address", type: "address" }],
+        name: "walletsPerStakeholder",
+        outputs: [{ name: "", internalType: "bytes16", type: "bytes16" }],
+        stateMutability: "view",
+    },
+    {
+        type: "event",
+        anonymous: false,
+        inputs: [
+            { name: "stakeholderId", internalType: "bytes16", type: "bytes16", indexed: true },
+            { name: "securityId", internalType: "bytes16", type: "bytes16", indexed: true },
+            { name: "stockClassId", internalType: "bytes16", type: "bytes16", indexed: true },
+            { name: "quantity", internalType: "uint256", type: "uint256", indexed: false },
+        ],
+        name: "ActivePositionMinted",
+    },
+    { type: "event", anonymous: false, inputs: [], name: "DefaultAdminDelayChangeCanceled" },
+    {
+        type: "event",
+        anonymous: false,
+        inputs: [
+            { name: "newDelay", internalType: "uint48", type: "uint48", indexed: false },
+            { name: "effectSchedule", internalType: "uint48", type: "uint48", indexed: false },
+        ],
+        name: "DefaultAdminDelayChangeScheduled",
+    },
+    { type: "event", anonymous: false, inputs: [], name: "DefaultAdminTransferCanceled" },
+    {
+        type: "event",
+        anonymous: false,
+        inputs: [
+            { name: "newAdmin", internalType: "address", type: "address", indexed: true },
+            { name: "acceptSchedule", internalType: "uint48", type: "uint48", indexed: false },
+        ],
+        name: "DefaultAdminTransferScheduled",
+    },
+    { type: "event", anonymous: false, inputs: [{ name: "version", internalType: "uint64", type: "uint64", indexed: false }], name: "Initialized" },
+    {
+        type: "event",
+        anonymous: false,
+        inputs: [
+            { name: "id", internalType: "bytes16", type: "bytes16", indexed: true },
+            { name: "_name", internalType: "string", type: "string", indexed: true },
+        ],
+        name: "IssuerCreated",
+    },
+    {
+        type: "event",
+        anonymous: false,
+        inputs: [
+            { name: "role", internalType: "bytes32", type: "bytes32", indexed: true },
+            { name: "previousAdminRole", internalType: "bytes32", type: "bytes32", indexed: true },
+            { name: "newAdminRole", internalType: "bytes32", type: "bytes32", indexed: true },
+        ],
+        name: "RoleAdminChanged",
+    },
+    {
+        type: "event",
+        anonymous: false,
+        inputs: [
+            { name: "role", internalType: "bytes32", type: "bytes32", indexed: true },
+            { name: "account", internalType: "address", type: "address", indexed: true },
+            { name: "sender", internalType: "address", type: "address", indexed: true },
+        ],
+        name: "RoleGranted",
+    },
+    {
+        type: "event",
+        anonymous: false,
+        inputs: [
+            { name: "role", internalType: "bytes32", type: "bytes32", indexed: true },
+            { name: "account", internalType: "address", type: "address", indexed: true },
+            { name: "sender", internalType: "address", type: "address", indexed: true },
+        ],
+        name: "RoleRevoked",
+    },
+    {
+        type: "event",
+        anonymous: false,
+        inputs: [
+            { name: "issuerId", internalType: "bytes16", type: "bytes16", indexed: true },
+            { name: "sharesAuthorized", internalType: "uint256", type: "uint256", indexed: false },
+            { name: "sharesIssued", internalType: "uint256", type: "uint256", indexed: false },
+        ],
+        name: "SharesAuthorizedMinted",
+    },
+    {
+        type: "event",
+        anonymous: false,
+        inputs: [{ name: "id", internalType: "bytes16", type: "bytes16", indexed: true }],
+        name: "StakeholderCreated",
+    },
+    {
+        type: "event",
+        anonymous: false,
+        inputs: [
+            { name: "id", internalType: "bytes16", type: "bytes16", indexed: true },
+            { name: "classType", internalType: "string", type: "string", indexed: true },
+            { name: "pricePerShare", internalType: "uint256", type: "uint256", indexed: true },
+            { name: "initialSharesAuthorized", internalType: "uint256", type: "uint256", indexed: false },
+        ],
+        name: "StockClassCreated",
+    },
+    {
+        type: "event",
+        anonymous: false,
+        inputs: [{ name: "id", internalType: "bytes16", type: "bytes16", indexed: true }],
+        name: "StockLegendTemplateCreated",
+    },
+    {
+        type: "event",
+        anonymous: false,
+        inputs: [
+            { name: "stakeholderId", internalType: "bytes16", type: "bytes16", indexed: true },
+            { name: "wallet", internalType: "address", type: "address", indexed: true },
+        ],
+        name: "WalletAdded",
+    },
+    {
+        type: "event",
+        anonymous: false,
+        inputs: [
+            { name: "stakeholderId", internalType: "bytes16", type: "bytes16", indexed: true },
+            { name: "wallet", internalType: "address", type: "address", indexed: true },
+        ],
+        name: "WalletRemoved",
+    },
+    { type: "error", inputs: [], name: "AccessControlBadConfirmation" },
+    { type: "error", inputs: [{ name: "schedule", internalType: "uint48", type: "uint48" }], name: "AccessControlEnforcedDefaultAdminDelay" },
+    { type: "error", inputs: [], name: "AccessControlEnforcedDefaultAdminRules" },
+    { type: "error", inputs: [{ name: "defaultAdmin", internalType: "address", type: "address" }], name: "AccessControlInvalidDefaultAdmin" },
+    {
+        type: "error",
+        inputs: [
+            { name: "account", internalType: "address", type: "address" },
+            { name: "neededRole", internalType: "bytes32", type: "bytes32" },
+        ],
+        name: "AccessControlUnauthorizedAccount",
+    },
+    { type: "error", inputs: [], name: "InvalidInitialization" },
+    { type: "error", inputs: [{ name: "stock_class_id", internalType: "bytes16", type: "bytes16" }], name: "InvalidStockClass" },
+    { type: "error", inputs: [{ name: "wallet", internalType: "address", type: "address" }], name: "InvalidWallet" },
+    { type: "error", inputs: [], name: "NoActivePositionFound" },
+    { type: "error", inputs: [], name: "NoIssuanceFound" },
+    { type: "error", inputs: [{ name: "stakeholder_id", internalType: "bytes16", type: "bytes16" }], name: "NoStakeholder" },
+    { type: "error", inputs: [], name: "NotInitializing" },
+    {
+        type: "error",
+        inputs: [
+            { name: "bits", internalType: "uint8", type: "uint8" },
+            { name: "value", internalType: "uint256", type: "uint256" },
+        ],
+        name: "SafeCastOverflowedUintDowncast",
+    },
+    { type: "error", inputs: [{ name: "stakeholder_id", internalType: "bytes16", type: "bytes16" }], name: "StakeholderAlreadyExists" },
+    { type: "error", inputs: [{ name: "stock_class_id", internalType: "bytes16", type: "bytes16" }], name: "StockClassAlreadyExists" },
+    { type: "error", inputs: [{ name: "wallet", internalType: "address", type: "address" }], name: "WalletAlreadyExists" },
+] as const;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // CapTableFactory
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -93,6 +863,657 @@ export const capTableFactoryAbi = [
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // React
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__
+ */
+export const useReadCapTable = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"ADMIN_ROLE"`
+ */
+export const useReadCapTableAdminRole = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "ADMIN_ROLE" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"DEFAULT_ADMIN_ROLE"`
+ */
+export const useReadCapTableDefaultAdminRole = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "DEFAULT_ADMIN_ROLE" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"OPERATOR_ROLE"`
+ */
+export const useReadCapTableOperatorRole = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "OPERATOR_ROLE" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"defaultAdmin"`
+ */
+export const useReadCapTableDefaultAdmin = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "defaultAdmin" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"defaultAdminDelay"`
+ */
+export const useReadCapTableDefaultAdminDelay = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "defaultAdminDelay" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"defaultAdminDelayIncreaseWait"`
+ */
+export const useReadCapTableDefaultAdminDelayIncreaseWait = /*#__PURE__*/ createUseReadContract({
+    abi: capTableAbi,
+    functionName: "defaultAdminDelayIncreaseWait",
+});
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"getActivePosition"`
+ */
+export const useReadCapTableGetActivePosition = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "getActivePosition" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"getAveragePosition"`
+ */
+export const useReadCapTableGetAveragePosition = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "getAveragePosition" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"getRoleAdmin"`
+ */
+export const useReadCapTableGetRoleAdmin = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "getRoleAdmin" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"getStakeholderById"`
+ */
+export const useReadCapTableGetStakeholderById = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "getStakeholderById" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"getStakeholderIdByWallet"`
+ */
+export const useReadCapTableGetStakeholderIdByWallet = /*#__PURE__*/ createUseReadContract({
+    abi: capTableAbi,
+    functionName: "getStakeholderIdByWallet",
+});
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"getStockClassById"`
+ */
+export const useReadCapTableGetStockClassById = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "getStockClassById" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"getTotalActiveSecuritiesCount"`
+ */
+export const useReadCapTableGetTotalActiveSecuritiesCount = /*#__PURE__*/ createUseReadContract({
+    abi: capTableAbi,
+    functionName: "getTotalActiveSecuritiesCount",
+});
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"getTotalNumberOfStakeholders"`
+ */
+export const useReadCapTableGetTotalNumberOfStakeholders = /*#__PURE__*/ createUseReadContract({
+    abi: capTableAbi,
+    functionName: "getTotalNumberOfStakeholders",
+});
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"getTotalNumberOfStockClasses"`
+ */
+export const useReadCapTableGetTotalNumberOfStockClasses = /*#__PURE__*/ createUseReadContract({
+    abi: capTableAbi,
+    functionName: "getTotalNumberOfStockClasses",
+});
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"getTransactionsCount"`
+ */
+export const useReadCapTableGetTransactionsCount = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "getTransactionsCount" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"hasRole"`
+ */
+export const useReadCapTableHasRole = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "hasRole" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"issuer"`
+ */
+export const useReadCapTableIssuer = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "issuer" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"nonce"`
+ */
+export const useReadCapTableNonce = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "nonce" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"owner"`
+ */
+export const useReadCapTableOwner = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "owner" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"pendingDefaultAdmin"`
+ */
+export const useReadCapTablePendingDefaultAdmin = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "pendingDefaultAdmin" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"pendingDefaultAdminDelay"`
+ */
+export const useReadCapTablePendingDefaultAdminDelay = /*#__PURE__*/ createUseReadContract({
+    abi: capTableAbi,
+    functionName: "pendingDefaultAdminDelay",
+});
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"stakeholderIndex"`
+ */
+export const useReadCapTableStakeholderIndex = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "stakeholderIndex" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"stakeholders"`
+ */
+export const useReadCapTableStakeholders = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "stakeholders" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"stockClassIndex"`
+ */
+export const useReadCapTableStockClassIndex = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "stockClassIndex" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"stockClasses"`
+ */
+export const useReadCapTableStockClasses = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "stockClasses" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"stockLegendTemplates"`
+ */
+export const useReadCapTableStockLegendTemplates = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "stockLegendTemplates" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"supportsInterface"`
+ */
+export const useReadCapTableSupportsInterface = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "supportsInterface" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"transactions"`
+ */
+export const useReadCapTableTransactions = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "transactions" });
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"walletsPerStakeholder"`
+ */
+export const useReadCapTableWalletsPerStakeholder = /*#__PURE__*/ createUseReadContract({ abi: capTableAbi, functionName: "walletsPerStakeholder" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__
+ */
+export const useWriteCapTable = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"acceptDefaultAdminTransfer"`
+ */
+export const useWriteCapTableAcceptDefaultAdminTransfer = /*#__PURE__*/ createUseWriteContract({
+    abi: capTableAbi,
+    functionName: "acceptDefaultAdminTransfer",
+});
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"acceptStock"`
+ */
+export const useWriteCapTableAcceptStock = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "acceptStock" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"addAdmin"`
+ */
+export const useWriteCapTableAddAdmin = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "addAdmin" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"addOperator"`
+ */
+export const useWriteCapTableAddOperator = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "addOperator" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"addWalletToStakeholder"`
+ */
+export const useWriteCapTableAddWalletToStakeholder = /*#__PURE__*/ createUseWriteContract({
+    abi: capTableAbi,
+    functionName: "addWalletToStakeholder",
+});
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"adjustIssuerAuthorizedShares"`
+ */
+export const useWriteCapTableAdjustIssuerAuthorizedShares = /*#__PURE__*/ createUseWriteContract({
+    abi: capTableAbi,
+    functionName: "adjustIssuerAuthorizedShares",
+});
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"adjustStockClassAuthorizedShares"`
+ */
+export const useWriteCapTableAdjustStockClassAuthorizedShares = /*#__PURE__*/ createUseWriteContract({
+    abi: capTableAbi,
+    functionName: "adjustStockClassAuthorizedShares",
+});
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"beginDefaultAdminTransfer"`
+ */
+export const useWriteCapTableBeginDefaultAdminTransfer = /*#__PURE__*/ createUseWriteContract({
+    abi: capTableAbi,
+    functionName: "beginDefaultAdminTransfer",
+});
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"cancelDefaultAdminTransfer"`
+ */
+export const useWriteCapTableCancelDefaultAdminTransfer = /*#__PURE__*/ createUseWriteContract({
+    abi: capTableAbi,
+    functionName: "cancelDefaultAdminTransfer",
+});
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"cancelStock"`
+ */
+export const useWriteCapTableCancelStock = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "cancelStock" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"changeDefaultAdminDelay"`
+ */
+export const useWriteCapTableChangeDefaultAdminDelay = /*#__PURE__*/ createUseWriteContract({
+    abi: capTableAbi,
+    functionName: "changeDefaultAdminDelay",
+});
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"createStakeholder"`
+ */
+export const useWriteCapTableCreateStakeholder = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "createStakeholder" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"createStockClass"`
+ */
+export const useWriteCapTableCreateStockClass = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "createStockClass" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"createStockLegendTemplate"`
+ */
+export const useWriteCapTableCreateStockLegendTemplate = /*#__PURE__*/ createUseWriteContract({
+    abi: capTableAbi,
+    functionName: "createStockLegendTemplate",
+});
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"grantRole"`
+ */
+export const useWriteCapTableGrantRole = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "grantRole" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"initialize"`
+ */
+export const useWriteCapTableInitialize = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "initialize" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"issueStock"`
+ */
+export const useWriteCapTableIssueStock = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "issueStock" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"mintActivePositions"`
+ */
+export const useWriteCapTableMintActivePositions = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "mintActivePositions" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"mintSharesAuthorized"`
+ */
+export const useWriteCapTableMintSharesAuthorized = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "mintSharesAuthorized" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"reissueStock"`
+ */
+export const useWriteCapTableReissueStock = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "reissueStock" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"removeAdmin"`
+ */
+export const useWriteCapTableRemoveAdmin = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "removeAdmin" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"removeOperator"`
+ */
+export const useWriteCapTableRemoveOperator = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "removeOperator" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"removeWalletFromStakeholder"`
+ */
+export const useWriteCapTableRemoveWalletFromStakeholder = /*#__PURE__*/ createUseWriteContract({
+    abi: capTableAbi,
+    functionName: "removeWalletFromStakeholder",
+});
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"renounceRole"`
+ */
+export const useWriteCapTableRenounceRole = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "renounceRole" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"repurchaseStock"`
+ */
+export const useWriteCapTableRepurchaseStock = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "repurchaseStock" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"retractStockIssuance"`
+ */
+export const useWriteCapTableRetractStockIssuance = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "retractStockIssuance" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"revokeRole"`
+ */
+export const useWriteCapTableRevokeRole = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "revokeRole" });
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"rollbackDefaultAdminDelay"`
+ */
+export const useWriteCapTableRollbackDefaultAdminDelay = /*#__PURE__*/ createUseWriteContract({
+    abi: capTableAbi,
+    functionName: "rollbackDefaultAdminDelay",
+});
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"transferStock"`
+ */
+export const useWriteCapTableTransferStock = /*#__PURE__*/ createUseWriteContract({ abi: capTableAbi, functionName: "transferStock" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__
+ */
+export const useSimulateCapTable = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"acceptDefaultAdminTransfer"`
+ */
+export const useSimulateCapTableAcceptDefaultAdminTransfer = /*#__PURE__*/ createUseSimulateContract({
+    abi: capTableAbi,
+    functionName: "acceptDefaultAdminTransfer",
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"acceptStock"`
+ */
+export const useSimulateCapTableAcceptStock = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "acceptStock" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"addAdmin"`
+ */
+export const useSimulateCapTableAddAdmin = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "addAdmin" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"addOperator"`
+ */
+export const useSimulateCapTableAddOperator = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "addOperator" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"addWalletToStakeholder"`
+ */
+export const useSimulateCapTableAddWalletToStakeholder = /*#__PURE__*/ createUseSimulateContract({
+    abi: capTableAbi,
+    functionName: "addWalletToStakeholder",
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"adjustIssuerAuthorizedShares"`
+ */
+export const useSimulateCapTableAdjustIssuerAuthorizedShares = /*#__PURE__*/ createUseSimulateContract({
+    abi: capTableAbi,
+    functionName: "adjustIssuerAuthorizedShares",
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"adjustStockClassAuthorizedShares"`
+ */
+export const useSimulateCapTableAdjustStockClassAuthorizedShares = /*#__PURE__*/ createUseSimulateContract({
+    abi: capTableAbi,
+    functionName: "adjustStockClassAuthorizedShares",
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"beginDefaultAdminTransfer"`
+ */
+export const useSimulateCapTableBeginDefaultAdminTransfer = /*#__PURE__*/ createUseSimulateContract({
+    abi: capTableAbi,
+    functionName: "beginDefaultAdminTransfer",
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"cancelDefaultAdminTransfer"`
+ */
+export const useSimulateCapTableCancelDefaultAdminTransfer = /*#__PURE__*/ createUseSimulateContract({
+    abi: capTableAbi,
+    functionName: "cancelDefaultAdminTransfer",
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"cancelStock"`
+ */
+export const useSimulateCapTableCancelStock = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "cancelStock" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"changeDefaultAdminDelay"`
+ */
+export const useSimulateCapTableChangeDefaultAdminDelay = /*#__PURE__*/ createUseSimulateContract({
+    abi: capTableAbi,
+    functionName: "changeDefaultAdminDelay",
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"createStakeholder"`
+ */
+export const useSimulateCapTableCreateStakeholder = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "createStakeholder" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"createStockClass"`
+ */
+export const useSimulateCapTableCreateStockClass = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "createStockClass" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"createStockLegendTemplate"`
+ */
+export const useSimulateCapTableCreateStockLegendTemplate = /*#__PURE__*/ createUseSimulateContract({
+    abi: capTableAbi,
+    functionName: "createStockLegendTemplate",
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"grantRole"`
+ */
+export const useSimulateCapTableGrantRole = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "grantRole" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"initialize"`
+ */
+export const useSimulateCapTableInitialize = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "initialize" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"issueStock"`
+ */
+export const useSimulateCapTableIssueStock = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "issueStock" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"mintActivePositions"`
+ */
+export const useSimulateCapTableMintActivePositions = /*#__PURE__*/ createUseSimulateContract({
+    abi: capTableAbi,
+    functionName: "mintActivePositions",
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"mintSharesAuthorized"`
+ */
+export const useSimulateCapTableMintSharesAuthorized = /*#__PURE__*/ createUseSimulateContract({
+    abi: capTableAbi,
+    functionName: "mintSharesAuthorized",
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"reissueStock"`
+ */
+export const useSimulateCapTableReissueStock = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "reissueStock" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"removeAdmin"`
+ */
+export const useSimulateCapTableRemoveAdmin = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "removeAdmin" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"removeOperator"`
+ */
+export const useSimulateCapTableRemoveOperator = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "removeOperator" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"removeWalletFromStakeholder"`
+ */
+export const useSimulateCapTableRemoveWalletFromStakeholder = /*#__PURE__*/ createUseSimulateContract({
+    abi: capTableAbi,
+    functionName: "removeWalletFromStakeholder",
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"renounceRole"`
+ */
+export const useSimulateCapTableRenounceRole = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "renounceRole" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"repurchaseStock"`
+ */
+export const useSimulateCapTableRepurchaseStock = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "repurchaseStock" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"retractStockIssuance"`
+ */
+export const useSimulateCapTableRetractStockIssuance = /*#__PURE__*/ createUseSimulateContract({
+    abi: capTableAbi,
+    functionName: "retractStockIssuance",
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"revokeRole"`
+ */
+export const useSimulateCapTableRevokeRole = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "revokeRole" });
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"rollbackDefaultAdminDelay"`
+ */
+export const useSimulateCapTableRollbackDefaultAdminDelay = /*#__PURE__*/ createUseSimulateContract({
+    abi: capTableAbi,
+    functionName: "rollbackDefaultAdminDelay",
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link capTableAbi}__ and `functionName` set to `"transferStock"`
+ */
+export const useSimulateCapTableTransferStock = /*#__PURE__*/ createUseSimulateContract({ abi: capTableAbi, functionName: "transferStock" });
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__
+ */
+export const useWatchCapTableEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: capTableAbi });
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"ActivePositionMinted"`
+ */
+export const useWatchCapTableActivePositionMintedEvent = /*#__PURE__*/ createUseWatchContractEvent({
+    abi: capTableAbi,
+    eventName: "ActivePositionMinted",
+});
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"DefaultAdminDelayChangeCanceled"`
+ */
+export const useWatchCapTableDefaultAdminDelayChangeCanceledEvent = /*#__PURE__*/ createUseWatchContractEvent({
+    abi: capTableAbi,
+    eventName: "DefaultAdminDelayChangeCanceled",
+});
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"DefaultAdminDelayChangeScheduled"`
+ */
+export const useWatchCapTableDefaultAdminDelayChangeScheduledEvent = /*#__PURE__*/ createUseWatchContractEvent({
+    abi: capTableAbi,
+    eventName: "DefaultAdminDelayChangeScheduled",
+});
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"DefaultAdminTransferCanceled"`
+ */
+export const useWatchCapTableDefaultAdminTransferCanceledEvent = /*#__PURE__*/ createUseWatchContractEvent({
+    abi: capTableAbi,
+    eventName: "DefaultAdminTransferCanceled",
+});
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"DefaultAdminTransferScheduled"`
+ */
+export const useWatchCapTableDefaultAdminTransferScheduledEvent = /*#__PURE__*/ createUseWatchContractEvent({
+    abi: capTableAbi,
+    eventName: "DefaultAdminTransferScheduled",
+});
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"Initialized"`
+ */
+export const useWatchCapTableInitializedEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: capTableAbi, eventName: "Initialized" });
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"IssuerCreated"`
+ */
+export const useWatchCapTableIssuerCreatedEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: capTableAbi, eventName: "IssuerCreated" });
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"RoleAdminChanged"`
+ */
+export const useWatchCapTableRoleAdminChangedEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: capTableAbi, eventName: "RoleAdminChanged" });
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"RoleGranted"`
+ */
+export const useWatchCapTableRoleGrantedEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: capTableAbi, eventName: "RoleGranted" });
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"RoleRevoked"`
+ */
+export const useWatchCapTableRoleRevokedEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: capTableAbi, eventName: "RoleRevoked" });
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"SharesAuthorizedMinted"`
+ */
+export const useWatchCapTableSharesAuthorizedMintedEvent = /*#__PURE__*/ createUseWatchContractEvent({
+    abi: capTableAbi,
+    eventName: "SharesAuthorizedMinted",
+});
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"StakeholderCreated"`
+ */
+export const useWatchCapTableStakeholderCreatedEvent = /*#__PURE__*/ createUseWatchContractEvent({
+    abi: capTableAbi,
+    eventName: "StakeholderCreated",
+});
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"StockClassCreated"`
+ */
+export const useWatchCapTableStockClassCreatedEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: capTableAbi, eventName: "StockClassCreated" });
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"StockLegendTemplateCreated"`
+ */
+export const useWatchCapTableStockLegendTemplateCreatedEvent = /*#__PURE__*/ createUseWatchContractEvent({
+    abi: capTableAbi,
+    eventName: "StockLegendTemplateCreated",
+});
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"WalletAdded"`
+ */
+export const useWatchCapTableWalletAddedEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: capTableAbi, eventName: "WalletAdded" });
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link capTableAbi}__ and `eventName` set to `"WalletRemoved"`
+ */
+export const useWatchCapTableWalletRemovedEvent = /*#__PURE__*/ createUseWatchContractEvent({ abi: capTableAbi, eventName: "WalletRemoved" });
 
 /**
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link capTableFactoryAbi}__

--- a/app/src/hooks/useCapTableManager.ts
+++ b/app/src/hooks/useCapTableManager.ts
@@ -1,0 +1,169 @@
+import { useState, useCallback, useEffect } from "react";
+import type { IssuerResponse } from "../services/registerIssuer";
+import { createStockClass, type CreateStockClassPayload, type StockClassResponse } from "../services/createStockClass";
+import { createStakeholder, type CreateStakeholderPayload, type StakeholderResponse } from "../services/createStakeholder";
+import { createStockIssuance, type CreateStockIssuancePayload, type StockIssuanceResponse } from "../services/createStockIssuance";
+
+export interface HoldingsData {
+	issuer?: any;
+	stockClasses?: any[];
+	holdings?: Array<{
+		stakeholder: any;
+		stockClass: any;
+		quantity: string;
+		sharePrice?: any;
+	}>;
+}
+
+export interface UseCapTableManagerReturn {
+	// Context from successful mint
+	issuer: IssuerResponse | null;
+	contractAddress: string | null;
+
+	// Fetched / derived data (primary source for the table)
+	holdings: HoldingsData | null;
+	isLoadingHoldings: boolean;
+	holdingsError: string | null;
+
+	// Local optimistic lists (for instant UI feedback + dropdowns before poller/refresh)
+	createdStockClasses: StockClassResponse["stockClass"][];
+	createdStakeholders: StakeholderResponse["stakeholder"][];
+	createdIssuances: StockIssuanceResponse["stockIssuance"][];
+
+	// Create actions for the legacy server-operator flow (server signs the onchain tx).
+	// Direct wallet flows go through the registerXxxOnchain services, not through this manager.
+	createStockClass: (data: CreateStockClassPayload["data"]) => Promise<void>;
+	createStakeholder: (data: CreateStakeholderPayload["data"]) => Promise<void>;
+	createStockIssuance: (data: CreateStockIssuancePayload["data"]) => Promise<void>;
+
+	// Manual refresh
+	refreshHoldings: () => void;
+
+	// Errors per action (simple string for StatusBox)
+	lastError: string | null;
+	clearError: () => void;
+}
+
+export function useCapTableManager(issuerResult: IssuerResponse | null): UseCapTableManagerReturn {
+	const [holdings, setHoldings] = useState<HoldingsData | null>(null);
+	const [isLoadingHoldings, setIsLoadingHoldings] = useState(false);
+	const [holdingsError, setHoldingsError] = useState<string | null>(null);
+
+	const [createdStockClasses, setCreatedStockClasses] = useState<any[]>([]);
+	const [createdStakeholders, setCreatedStakeholders] = useState<any[]>([]);
+	const [createdIssuances, setCreatedIssuances] = useState<any[]>([]);
+
+	const [lastError, setLastError] = useState<string | null>(null);
+
+	const issuerId = issuerResult?._id ?? null;
+	const contractAddress = issuerResult?.deployed_to ?? null;
+
+	const fetchHoldings = useCallback(async () => {
+		if (!issuerId) return;
+		setIsLoadingHoldings(true);
+		setHoldingsError(null);
+		try {
+			const res = await fetch(`/api/cap-table/holdings/stock?issuerId=${encodeURIComponent(issuerId)}`);
+			if (!res.ok) {
+				const text = await res.text();
+				throw new Error(text || `Failed to load holdings (${res.status})`);
+			}
+			const data = await res.json();
+			setHoldings(data);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			setHoldingsError(msg);
+		} finally {
+			setIsLoadingHoldings(false);
+		}
+	}, [issuerId]);
+
+	// Auto-fetch holdings once we have a successful issuer result in this session
+	useEffect(() => {
+		if (issuerId) {
+			fetchHoldings();
+		} else {
+			// Reset when mint result is cleared
+			setHoldings(null);
+			setCreatedStockClasses([]);
+			setCreatedStakeholders([]);
+			setCreatedIssuances([]);
+		}
+	}, [issuerId, fetchHoldings]);
+
+	const refreshHoldings = useCallback(() => {
+		fetchHoldings();
+	}, [fetchHoldings]);
+
+	const clearError = useCallback(() => setLastError(null), []);
+
+	const handleCreateStockClass = useCallback(
+		async (data: CreateStockClassPayload["data"]) => {
+			if (!issuerId) return;
+			setLastError(null);
+			try {
+				const res = await createStockClass({ issuerId, data });
+				setCreatedStockClasses((prev) => [...prev, res.stockClass]);
+				// Refresh the authoritative table shortly after (poller will also update)
+				setTimeout(() => fetchHoldings(), 800);
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				setLastError(msg);
+				throw err;
+			}
+		},
+		[issuerId, fetchHoldings],
+	);
+
+	const handleCreateStakeholder = useCallback(
+		async (data: CreateStakeholderPayload["data"]) => {
+			if (!issuerId) return;
+			setLastError(null);
+			try {
+				const res = await createStakeholder({ issuerId, data });
+				setCreatedStakeholders((prev) => [...prev, res.stakeholder]);
+				setTimeout(() => fetchHoldings(), 800);
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				setLastError(msg);
+				throw err;
+			}
+		},
+		[issuerId, fetchHoldings],
+	);
+
+	const handleCreateStockIssuance = useCallback(
+		async (data: CreateStockIssuancePayload["data"]) => {
+			if (!issuerId) return;
+			setLastError(null);
+			try {
+				const payload: CreateStockIssuancePayload = { issuerId, data };
+				const res = await createStockIssuance(payload);
+				setCreatedIssuances((prev) => [...prev, res.stockIssuance]);
+				setTimeout(() => fetchHoldings(), 800);
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				setLastError(msg);
+				throw err;
+			}
+		},
+		[issuerId, fetchHoldings],
+	);
+
+	return {
+		issuer: issuerResult,
+		contractAddress,
+		holdings,
+		isLoadingHoldings,
+		holdingsError,
+		createdStockClasses,
+		createdStakeholders,
+		createdIssuances,
+		createStockClass: handleCreateStockClass,
+		createStakeholder: handleCreateStakeholder,
+		createStockIssuance: handleCreateStockIssuance,
+		refreshHoldings,
+		lastError,
+		clearError,
+	};
+}

--- a/app/src/hooks/useDirectCreateStakeholder.ts
+++ b/app/src/hooks/useDirectCreateStakeholder.ts
@@ -1,0 +1,61 @@
+import { useCallback } from "react";
+import { useAccount } from "wagmi";
+import { useWriteCapTableCreateStakeholder } from "../generated";
+import { generateBytes16Id } from "../utils/uuid";
+
+interface DirectCreateStakeholderParams {
+  capTableAddress: `0x${string}`;
+  stakeholderType: "INDIVIDUAL" | "INSTITUTION";
+  currentRelationship: string;
+}
+
+export function useDirectCreateStakeholder() {
+  const { address: connectedAddress } = useAccount();
+
+  const {
+    writeContract,
+    data: hash,
+    isPending: isWritePending,
+    error: writeError,
+    reset,
+  } = useWriteCapTableCreateStakeholder();
+
+  const createStakeholder = useCallback(
+    async (params: DirectCreateStakeholderParams & { id?: `0x${string}` }) => {
+      if (!connectedAddress) {
+        throw new Error("Please connect your wallet");
+      }
+      if (!params.capTableAddress) {
+        throw new Error("Cap table address is required");
+      }
+
+      // Allow caller to supply the id (so we can use the exact same bytes16 for both the onchain tx
+      // and the subsequent offchain metadata record). Otherwise generate one.
+      const stakeholderId = params.id || generateBytes16Id();
+
+      writeContract({
+        address: params.capTableAddress,
+        args: [
+          stakeholderId,
+          params.stakeholderType,
+          params.currentRelationship,
+        ],
+      });
+
+      // Note: We do NOT return `hash` here. The hash from `useWriteContract` is updated
+      // asynchronously. Consumers should use the `hash` value exposed by this hook after
+      // calling the action (or better, use `useWaitForTransactionReceipt` for confirmation).
+      return { stakeholderId };
+    },
+    [writeContract, connectedAddress]
+  );
+
+  return {
+    createStakeholder,
+    hash,                    // Current hash from the write (updated after submission)
+    isWritePending,
+    writeError,
+    reset,
+    isConnected: !!connectedAddress,
+  };
+}

--- a/app/src/hooks/useDirectCreateStockClass.ts
+++ b/app/src/hooks/useDirectCreateStockClass.ts
@@ -1,0 +1,77 @@
+import { useCallback } from "react";
+import { useAccount } from "wagmi";
+import { useWriteCapTableCreateStockClass } from "../generated";
+import { generateBytes16Id } from "../utils/uuid";
+
+interface DirectCreateStockClassParams {
+  capTableAddress: `0x${string}`;
+  classType: "COMMON" | "PREFERRED";
+  pricePerShareAmount: string; // human readable, e.g. "4.20"
+  initialSharesAuthorized: string; // e.g. "1000000"
+}
+
+export function useDirectCreateStockClass() {
+  const { address: connectedAddress } = useAccount();
+
+  const {
+    writeContract,
+    data: hash,
+    isPending: isWritePending,
+    error: writeError,
+    reset,
+  } = useWriteCapTableCreateStockClass();
+
+  const createStockClass = useCallback(
+    async (params: DirectCreateStockClassParams & { id?: `0x${string}` }) => {
+      if (!connectedAddress) {
+        throw new Error("Please connect your wallet");
+      }
+      if (!params.capTableAddress) {
+        throw new Error("Cap table address is required");
+      }
+
+      // Generate a fresh bytes16 ID on the client (same pattern as mint flow).
+      // Caller can supply one so the same id is used for both the direct onchain tx
+      // and the offchain metadata record (prevents duplicate events + poller null races).
+      const stockClassId = params.id || generateBytes16Id();
+
+      // Scale the price (protocol uses 1e10 fixed point for prices)
+      const scaledPrice = scaleAmount(params.pricePerShareAmount);
+
+      // Shares authorized
+      const sharesAuthorized = BigInt(params.initialSharesAuthorized);
+
+      writeContract({
+        address: params.capTableAddress,
+        args: [
+          stockClassId,
+          params.classType,
+          scaledPrice,
+          sharesAuthorized,
+        ],
+      });
+
+      // Note: We intentionally do not return `hash` from the action.
+      // See useDirectCreateStakeholder.ts for explanation.
+      return { stockClassId };
+    },
+    [writeContract, connectedAddress]
+  );
+
+  return {
+    createStockClass,
+    hash,
+    isWritePending,
+    writeError,
+    reset,
+    isConnected: !!connectedAddress,
+  };
+}
+
+/** Scales a human decimal amount using the protocol's 1e10 fixed point */
+function scaleAmount(amount: string): bigint {
+  const SCALE = 10_000_000_000n; // 1e10
+  const value = parseFloat(amount);
+  if (isNaN(value)) throw new Error("Invalid price amount");
+  return BigInt(Math.round(value * Number(SCALE)));
+}

--- a/app/src/hooks/useDirectIssueStock.ts
+++ b/app/src/hooks/useDirectIssueStock.ts
@@ -1,0 +1,104 @@
+import { useCallback } from "react";
+import { useAccount } from "wagmi";
+import { useWriteCapTableIssueStock } from "../generated";
+import { generateBytes16Id, uuidToBytes16 } from "../utils/uuid";
+
+/** Minimal but valid params for direct onchain issuance (matches what the backend does) */
+interface DirectIssueStockParams {
+  capTableAddress: `0x${string}`;
+  stakeholderId: string;      // UUID
+  stockClassId: string;       // UUID
+  quantity: string;           // human, e.g. "100000"
+  sharePriceAmount: string;   // e.g. "4.20"
+  customId?: string;
+  comments?: string[];
+}
+
+export function useDirectIssueStock() {
+  const { address: connectedAddress } = useAccount();
+
+  const {
+    writeContract,
+    data: hash,
+    isPending: isWritePending,
+    error: writeError,
+    reset,
+  } = useWriteCapTableIssueStock();
+
+  const issueStock = useCallback(
+    async (params: DirectIssueStockParams) => {
+      if (!connectedAddress) {
+        throw new Error("Please connect your wallet");
+      }
+      if (!params.capTableAddress) {
+        throw new Error("Cap table address is required");
+      }
+
+      const issuanceId = generateBytes16Id();
+      const securityId = generateBytes16Id();
+
+      // uuidToBytes16 accepts UUID-with-dashes OR an already-0x bytes16 string, so we never
+      // end up with double 0x prefixes when the caller passes either form.
+      const stakeholderIdBytes = uuidToBytes16(params.stakeholderId);
+      const stockClassIdBytes = uuidToBytes16(params.stockClassId);
+      const zeroId = `0x${"0".repeat(32)}` as `0x${string}`;
+
+      // Scale price and quantity (1e10 fixed point, matching the rest of the system).
+      // The legacy server path applies toScaledBigNumber (= * 1e10) to both, and the poller
+      // unscales by 1e10 when persisting to Mongo. We mirror that here so quantities round-trip.
+      const scaledPrice = scaleAmount(params.sharePriceAmount);
+      const scaledQuantity = scaleAmount(params.quantity);
+
+      // Build the minimal valid StockIssuanceParams struct
+      const issuanceParams = {
+        stock_class_id: stockClassIdBytes,
+        stock_plan_id: zeroId,
+        share_numbers_issued: {
+          starting_share_number: 0n,
+          ending_share_number: 0n,
+        },
+        share_price: scaledPrice,
+        quantity: scaledQuantity,
+        vesting_terms_id: zeroId,
+        cost_basis: 0n,
+        stock_legend_ids: [] as `0x${string}`[],
+        issuance_type: "",
+        comments: params.comments || [],
+        custom_id: params.customId || "",
+        stakeholder_id: stakeholderIdBytes,
+        board_approval_date: "",
+        stockholder_approval_date: "",
+        consideration_text: "",
+        security_law_exemptions: [] as string[],
+      };
+
+      writeContract({
+        address: params.capTableAddress,
+        args: [issuanceParams],
+      });
+
+      // Note: We intentionally do not return `hash` from the action (it would be stale).
+      // Consumers should read `hash` from the hook return value after calling `issueStock`.
+      return { issuanceId, securityId };
+    },
+    [writeContract, connectedAddress]
+  );
+
+  return {
+    issueStock,
+    hash,
+    isWritePending,
+    writeError,
+    reset,
+    isConnected: !!connectedAddress,
+  };
+}
+
+/** 1e10 scaling helper (same as used elsewhere) */
+function scaleAmount(amount: string): bigint {
+  const SCALE = 10_000_000_000n;
+  const value = parseFloat(amount);
+  if (isNaN(value)) throw new Error("Invalid price amount");
+  return BigInt(Math.round(value * Number(SCALE)));
+}
+

--- a/app/src/hooks/useMintIssuer.ts
+++ b/app/src/hooks/useMintIssuer.ts
@@ -51,6 +51,7 @@ export interface UseMintIssuerReturn {
 
 	// Actions
 	handleMint: () => void;
+	reset: () => void;
 
 	// Results / errors
 	txHash: `0x${string}` | undefined;
@@ -135,6 +136,13 @@ export function useMintIssuer(): UseMintIssuerReturn {
 		});
 	}, [canMint, id, fields.legalName, fields.sharesAuthorized, writeContract, reset]);
 
+	const resetMint = useCallback(() => {
+		reset();
+		setDeployedAddress(null);
+		setServerError(null);
+		setResult(null);
+	}, [reset]);
+
 	// --- Step 2: parse event + register with server ---
 	useEffect(() => {
 		if (!receipt || !txHash || result || isRegistering) return;
@@ -176,6 +184,7 @@ export function useMintIssuer(): UseMintIssuerReturn {
 					comments: [],
 					deployed_to: proxyAddress,
 					tx_hash: txHash,
+					...(address && { deployed_by: address }),
 				};
 				const issuer = await registerIssuer(payload);
 				setResult(issuer);
@@ -197,6 +206,7 @@ export function useMintIssuer(): UseMintIssuerReturn {
 		isConfirming,
 		isRegistering,
 		handleMint,
+		reset: resetMint,
 		txHash,
 		isConfirmed,
 		deployedAddress,

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import GlobalStyle from "../components/globalstyle";
 import { IBM_Plex_Mono } from 'next/font/google';
 
 import Layout from "../components/layout";
+import { CapTableMenuProvider } from "../components/CapTableMenuContext";
 import Web3Provider from "../config/Web3Provider";
 
 // Configure our font object
@@ -43,6 +44,7 @@ export default function App({ Component, pageProps }: AppProps & { Component: Ne
 		<Web3Provider>
 			<ThemeProvider theme={theme}>
 				<GlobalStyle />
+				<CapTableMenuProvider>
 				<Layout className={plex.className}>
 					<Head>
 					<meta charSet="utf-8" />
@@ -83,6 +85,7 @@ export default function App({ Component, pageProps }: AppProps & { Component: Ne
 				</Head>
 					<Component {...pageProps} />
 				</Layout>
+				</CapTableMenuProvider>
 			</ThemeProvider>
 		</Web3Provider>
 	);

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -1,22 +1,19 @@
-import Link from "next/link";
-import { Heading, Content, StyledTable } from "../components/wrappers";
-import { H1, H2, P } from "../components/typography";
+import { Content, Heading, StyledTable } from "../components/wrappers";
+import { H2, P } from "../components/typography";
 
 export default function Home() {
 	return (
 		<Content>
 			<Heading>
-				<H1>Onchain cap tables.</H1>
-				<P>Tokenize RWAs, and handle post-trade settlement.</P>
-				<P>Based on the <a href="https://www.opencaptablecoalition.com/" target="_blank">Open Cap Table</a> data format, transfer agent protocol is being used by SEC-registered entities.</P>
-				<a href="https://paragraph.com/@thatalexpalmer/rwa-tokenization-protocol-stack-1" target="_blank" rel="noopener">Read why this exists</a>
-				
+				<P>Tokenize RWA cap tables and handle post-trade settlment.</P>
+				<P>Fully onchain protocol that's based on <a href="https://www.opencaptablecoalition.com/" target="_blank">Open Cap Table</a> data format. We're being used by SEC-registered transfer agents.</P>
+				<a href="https://paragraph.com/@thatalexpalmer/rwa-tokenization-protocol-stack-1" target="_blank" rel="noopener">Read how this started</a>
 			</Heading>
 			<H2>
-				Demo Deployments:
+				Demo contracts:
 			</H2>
 			<P>
-				Main implementation is being developed on <a href="https://plume.org" target="_blank">Plume</a> by <a href="https://palmer.earth" target="_blank">thatalexpalmer.eth</a> and will power <a href="https://plume.org/blog/plume-earns-sec-approval-as-transfer-agent" target="_blank">Plume's transfer agent.</a> Documentation is being updated.
+				Main implementation is being developed on <a href="https://plume.org" target="_blank">Plume</a> by <a href="https://palmer.earth" target="_blank">thatalexpalmer.eth</a> and will power <a href="https://plume.org/blog/plume-earns-sec-approval-as-transfer-agent" target="_blank">Plume's transfer agent.</a> Read our docs.
 			</P>
 			<StyledTable>
 				<thead>

--- a/app/src/pages/manage/cap-table.tsx
+++ b/app/src/pages/manage/cap-table.tsx
@@ -1,0 +1,153 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { P } from "../../components/typography";
+import { FullScreenStack, PageIntro } from "../../components/wrappers";
+import { CapTableDashboard } from "../../components/CapTableDashboard";
+import type { IssuerResponse } from "../../services/registerIssuer";
+import { getLastMintedIssuer, type LastMintedIssuer } from "../../utils/lastMintedIssuer";
+
+/**
+ * /manage/cap-table
+ *
+ * The main place to perform cap table operations:
+ * - Create stock classes
+ * - Create stakeholders
+ * - Issue stock
+ * - View holdings, etc.
+ *
+ * Supports:
+ * - ?issuerId=... in the URL (preferred, coming from /mint success)
+ * - Auto-loading the last minted issuer from localStorage
+ * - Graceful prompt if nothing is available
+ */
+export default function ManageCapTablePage() {
+	const router = useRouter();
+	const { issuerId: queryIssuerId } = router.query;
+
+	const [issuer, setIssuer] = useState<IssuerResponse | null>(null);
+	const [isLoading, setIsLoading] = useState(true);
+
+	useEffect(() => {
+		if (!router.isReady) return;
+
+		const tryLoad = async () => {
+			setIsLoading(true);
+
+			let loadedIssuer: IssuerResponse | null = null;
+
+			// 1. Prefer explicit ?issuerId from URL
+			if (typeof queryIssuerId === "string" && queryIssuerId.length > 0) {
+				// Prefer full issuer from the new /issuer/full/:id (gives legal_name, deployed_by, all OCF fields, etc.)
+				try {
+					const fullRes = await fetch(`/api/issuer/full/${encodeURIComponent(queryIssuerId)}`);
+					if (fullRes.ok) {
+						const full = await fullRes.json();
+						if (full && full._id) {
+							loadedIssuer = {
+								_id: full._id,
+								legal_name: full.legal_name || "Cap Table",
+								deployed_to: full.deployed_to || "",
+								tx_hash: full.tx_hash || "",
+							};
+						}
+					}
+				} catch {
+					// fall through to lastMintedIssuer fallback below
+				}
+
+				if (!loadedIssuer) {
+					// Fall back to lastMinted storage (has deployed_to from mint success)
+					const last = getLastMintedIssuer();
+					if (last && last._id === queryIssuerId) {
+						loadedIssuer = {
+							_id: last._id,
+							legal_name: last.legal_name || "Cap Table",
+							deployed_to: last.deployed_to || "",
+							tx_hash: last.tx_hash || "",
+						};
+					} else {
+						// Last resort: minimal object (direct signing still works once you know deployed_to)
+						loadedIssuer = {
+							_id: queryIssuerId,
+							legal_name: "Cap Table",
+							deployed_to: "",
+							tx_hash: "",
+						};
+					}
+				}
+			}
+
+			// 2. Fall back to last minted from localStorage (try full fetch too)
+			if (!loadedIssuer) {
+				const last: LastMintedIssuer | null = getLastMintedIssuer();
+				if (last) {
+					try {
+						const fullRes = await fetch(`/api/issuer/full/${encodeURIComponent(last._id)}`);
+						if (fullRes.ok) {
+							const full = await fullRes.json();
+							if (full?._id) {
+								loadedIssuer = {
+									_id: full._id,
+									legal_name: full.legal_name || last.legal_name || "Cap Table",
+									deployed_to: full.deployed_to || last.deployed_to || "",
+									tx_hash: full.tx_hash || last.tx_hash || "",
+								};
+							}
+						}
+					} catch {
+						// fall through to legacy lastMintedIssuer shape below
+					}
+					if (!loadedIssuer) {
+						loadedIssuer = {
+							_id: last._id,
+							legal_name: last.legal_name || "Cap Table",
+							deployed_to: last.deployed_to || "",
+							tx_hash: last.tx_hash || "",
+						};
+					}
+				}
+			}
+
+			if (loadedIssuer) {
+				setIssuer(loadedIssuer);
+			}
+
+			setIsLoading(false);
+		};
+
+		tryLoad();
+	}, [router.isReady, queryIssuerId]);
+
+	if (isLoading) {
+		return (
+			<FullScreenStack>
+				<PageIntro>
+					<P>Loading cap table...</P>
+				</PageIntro>
+			</FullScreenStack>
+		);
+	}
+
+	if (!issuer) {
+		return (
+			<FullScreenStack>
+				<PageIntro>
+					<P>
+						No cap table selected.{" "}
+						<a href="/mint">Mint a new one</a> or provide an <code>issuerId</code> in the URL.
+					</P>
+				</PageIntro>
+			</FullScreenStack>
+		);
+	}
+
+	return (
+		<CapTableDashboard
+			issuerResult={issuer}
+			onReset={() => {
+				// "Mint Another" from here sends user back to mint
+				router.push("/mint");
+			}}
+		/>
+	);
+}

--- a/app/src/pages/manage/index.tsx
+++ b/app/src/pages/manage/index.tsx
@@ -1,0 +1,238 @@
+import React, { useEffect, useState } from "react";
+import Link from "next/link";
+import { useAccount } from "wagmi";
+import { P } from "../../components/typography";
+import {
+	ActionTableLayout,
+	FullScreenStack,
+	MutedText,
+	PageIntro,
+	Panel,
+	SectionActions,
+	SectionHeader,
+	StyledTable,
+	TablePanel,
+	TableScroll,
+	TableTitle,
+} from "../../components/wrappers";
+import { InlineButton } from "../../components/buttons";
+import { FieldGroup, FieldLabel, Input } from "../../components/forms";
+import { getLastMintedIssuer, type LastMintedIssuer } from "../../utils/lastMintedIssuer";
+
+const MY_ISSUERS_KEY = "tap_my_issuers";
+
+/**
+ * /manage - Management Hub
+ *
+ * Shows all cap tables the admin wallet has interacted with (minted or manually added).
+ * This is the central place to pick which issuer to manage.
+ */
+export default function ManageHub() {
+	const [myIssuers, setMyIssuers] = useState<LastMintedIssuer[]>([]);
+	const [newIssuerId, setNewIssuerId] = useState("");
+	const [connectedAddress, setConnectedAddress] = useState<string | null>(null);
+	const { address: wagmiAddress } = useAccount();
+	const [isSyncingIssuers, setIsSyncingIssuers] = useState(false);
+
+	// Load persisted list + last minted
+	useEffect(() => {
+		if (typeof window === "undefined") return;
+
+		// Load saved list
+		try {
+			const saved = localStorage.getItem(MY_ISSUERS_KEY);
+			const parsed: LastMintedIssuer[] = saved ? JSON.parse(saved) : [];
+			setMyIssuers(parsed);
+		} catch {
+			// Ignore parse errors; the list will fall back to whatever is available below.
+		}
+
+		// Always include the most recent mint if it exists
+		const last = getLastMintedIssuer();
+		if (last) {
+			setMyIssuers((prev) => {
+				const exists = prev.some((i) => i._id === last._id);
+				return exists ? prev : [last, ...prev];
+			});
+		}
+	}, []);
+
+	// Save list whenever it changes
+	useEffect(() => {
+		if (typeof window === "undefined") return;
+		localStorage.setItem(MY_ISSUERS_KEY, JSON.stringify(myIssuers));
+	}, [myIssuers]);
+
+	// Track connected address for the "by admin" queries (real wagmi state)
+	useEffect(() => {
+		if (wagmiAddress) setConnectedAddress(wagmiAddress);
+	}, [wagmiAddress]);
+
+	const addIssuer = () => {
+		const id = newIssuerId.trim();
+		if (!id) return;
+
+		const newEntry: LastMintedIssuer = {
+			_id: id,
+			legal_name: "Manually added",
+			deployed_to: "",
+			tx_hash: "",
+		};
+
+		setMyIssuers((prev) => {
+			const exists = prev.some((i) => i._id === id);
+			return exists ? prev : [newEntry, ...prev];
+		});
+		setNewIssuerId("");
+	};
+
+	const removeIssuer = (id: string) => {
+		setMyIssuers((prev) => prev.filter((i) => i._id !== id));
+	};
+
+	// Pull issuers from server that were deployed_by the connected wallet (new capability)
+	const syncIssuersFromServer = async () => {
+		const addr = wagmiAddress || connectedAddress;
+		if (!addr) {
+			alert("Connect your admin wallet first (via the top Navbar) to query deployed issuers.");
+			return;
+		}
+		setIsSyncingIssuers(true);
+		try {
+			const res = await fetch(`/api/issuer/by-deployer/${encodeURIComponent(addr)}`);
+			if (res.ok) {
+				const json = await res.json();
+				const fromServer: LastMintedIssuer[] = (json.issuers || []).map((iss: any) => ({
+					_id: iss._id,
+					legal_name: iss.legal_name || "Cap Table",
+					deployed_to: iss.deployed_to || "",
+					tx_hash: iss.tx_hash || "",
+				}));
+				setMyIssuers((prev) => {
+					const merged = [...prev];
+					fromServer.forEach((s) => {
+						if (!merged.some((m) => m._id === s._id)) merged.unshift(s);
+					});
+					return merged;
+				});
+			} else {
+				console.warn("by-deployer returned", res.status);
+			}
+		} catch (e) {
+			console.error("Failed to sync issuers from server", e);
+		} finally {
+			setIsSyncingIssuers(false);
+		}
+	};
+
+	return (
+		<FullScreenStack>
+			<PageIntro>
+				<P>
+					This is your central hub for all cap tables you have deployed as Admin.
+					Your connected wallet can manage any of these.
+				</P>
+			</PageIntro>
+
+			<ActionTableLayout>
+				<Panel>
+					<SectionHeader>
+						<TableTitle>Add Existing Cap Table</TableTitle>
+					</SectionHeader>
+					<FieldGroup>
+						<FieldLabel>Issuer ID (UUID)</FieldLabel>
+						<Input
+							type="text"
+							value={newIssuerId}
+							onChange={(e) => setNewIssuerId(e.target.value)}
+							placeholder="Issuer ID (UUID)"
+						/>
+					</FieldGroup>
+					<SectionActions>
+						<InlineButton onClick={addIssuer} disabled={!newIssuerId.trim()} $variant="primary">
+							Add
+						</InlineButton>
+						<Link href="/mint" passHref legacyBehavior>
+							<InlineButton as="a">+ Mint a New Cap Table</InlineButton>
+						</Link>
+					</SectionActions>
+					<MutedText>
+						Paste any issuer ID you have admin rights on.
+					</MutedText>
+				</Panel>
+
+				<TablePanel>
+					<SectionHeader>
+						<TableTitle>Your Cap Tables</TableTitle>
+						<SectionActions>
+							<InlineButton
+								onClick={syncIssuersFromServer}
+								disabled={isSyncingIssuers || !wagmiAddress}
+								title="Query Mongo for issuers where deployed_by matches your connected wallet address"
+							>
+								{isSyncingIssuers ? "Syncing..." : "Sync from Server"}
+							</InlineButton>
+						</SectionActions>
+					</SectionHeader>
+
+					{myIssuers.length === 0 ? (
+						<MutedText>
+							No cap tables yet. Mint one on the <a href="/mint">Mint</a> page, or add an existing issuer ID.
+						</MutedText>
+					) : (
+						<TableScroll>
+							<StyledTable>
+								<thead>
+									<tr>
+										<th>Cap Table</th>
+										<th>Issuer ID</th>
+										<th>Contract</th>
+										<th>Actions</th>
+									</tr>
+								</thead>
+								<tbody>
+									{myIssuers.map((issuer) => (
+										<tr key={issuer._id}>
+											<td>{issuer.legal_name || "Unnamed Cap Table"}</td>
+											<td style={{ fontFamily: "monospace" }}>{issuer._id}</td>
+											<td style={{ fontFamily: "monospace" }}>
+												{issuer.deployed_to
+													? `${issuer.deployed_to.slice(0, 10)}…`
+													: "—"}
+											</td>
+											<td>
+												<SectionActions>
+													<Link
+														href={`/manage/cap-table?issuerId=${issuer._id}`}
+														passHref
+														legacyBehavior
+													>
+														<InlineButton as="a" $variant="primary">
+															Manage
+														</InlineButton>
+													</Link>
+													<InlineButton
+														onClick={() => removeIssuer(issuer._id)}
+														$variant="danger"
+													>
+														Remove
+													</InlineButton>
+												</SectionActions>
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</StyledTable>
+						</TableScroll>
+					)}
+
+					<MutedText>
+						Tip: every successful mint is automatically added. Use “Sync from Server” to
+						pull in any others deployed by this admin address (requires the deployed_by field
+						on recent mints).
+					</MutedText>
+				</TablePanel>
+			</ActionTableLayout>
+		</FullScreenStack>
+	);
+}

--- a/app/src/pages/mint.tsx
+++ b/app/src/pages/mint.tsx
@@ -1,26 +1,98 @@
-import { H2, P } from "../components/typography";
-import { MintLayout, Panel } from "../components/wrappers";
+import Link from "next/link";
+import { P } from "../components/typography";
+import {
+	ActionTableLayout,
+	FullScreenStack,
+	MutedText,
+	PageIntro,
+	Panel,
+	ResponseBlock,
+	SectionActions,
+	SectionHeader,
+	StatusBox,
+	TableTitle,
+} from "../components/wrappers";
+import { InlineButton } from "../components/buttons";
+import { FieldGroup as FormFieldGroup, FieldLabel as FormFieldLabel } from "../components/forms";
 import { IssuerForm } from "../components/IssuerForm";
 import { MintActions } from "../components/MintActions";
 import { useMintIssuer } from "../hooks/useMintIssuer";
+import { saveLastMintedIssuer } from "../utils/lastMintedIssuer";
 
 export default function MintPage() {
 	const mint = useMintIssuer();
 
-	return (
-		<>
-			<H2>Mint Cap Table</H2>
-			<P>
-				Deploy a new onchain cap table with your wallet. This feature is in dev preview — the
-				server isn't deployed yet, so minting will fail. Thanks for following our development.
-			</P>
+	// Clean post-mint success state — heavy management now lives at /manage/cap-table
+	if (mint.result) {
+		// Persist for /manage to auto-load
+		saveLastMintedIssuer(mint.result);
 
-			<MintLayout>
+		const manageUrl = `/manage/cap-table?issuerId=${encodeURIComponent(mint.result._id)}`;
+
+		return (
+			<FullScreenStack>
+				<PageIntro>
+					<TableTitle>Cap Table Minted Successfully</TableTitle>
+					<MutedText>
+						Your new cap table has been deployed and registered. Continue to the cap table manager
+						to create stock classes, stakeholders, and issue stock.
+					</MutedText>
+				</PageIntro>
+
+				<StatusBox $variant="success">
+					Your new cap table has been deployed and registered.
+				</StatusBox>
+
+				<FormFieldGroup>
+					<FormFieldLabel>Issuer ID</FormFieldLabel>
+					<ResponseBlock>{mint.result._id}</ResponseBlock>
+				</FormFieldGroup>
+				<FormFieldGroup>
+					<FormFieldLabel>Contract Address</FormFieldLabel>
+					<ResponseBlock>{mint.result.deployed_to}</ResponseBlock>
+				</FormFieldGroup>
+				<FormFieldGroup>
+					<FormFieldLabel>Transaction Hash</FormFieldLabel>
+					<ResponseBlock>{mint.result.tx_hash}</ResponseBlock>
+				</FormFieldGroup>
+
+				<SectionActions>
+					<Link href={manageUrl} passHref legacyBehavior>
+						<InlineButton as="a" $variant="primary">
+							Go to Manage → Create Stock Classes &amp; Issue Stock
+						</InlineButton>
+					</Link>
+					<InlineButton onClick={() => mint.reset()}>Mint Another</InlineButton>
+				</SectionActions>
+
+				<MutedText>
+					Use the top navigation to switch between Mint and Manage.
+				</MutedText>
+			</FullScreenStack>
+		);
+	}
+
+	return (
+		<FullScreenStack>
+			<PageIntro>
+				<P>
+					Deploy a new onchain cap table with your wallet. After minting, go to the Dashboard to create
+					stock classes, stakeholders, and issue stock.
+				</P>
+			</PageIntro>
+
+			<ActionTableLayout>
 				<Panel>
+					<SectionHeader>
+						<TableTitle>Issuer Details</TableTitle>
+					</SectionHeader>
 					<IssuerForm fields={mint.fields} setField={mint.setField} disabled={mint.isBusy} />
 				</Panel>
 
 				<Panel>
+					<SectionHeader>
+						<TableTitle>Mint</TableTitle>
+					</SectionHeader>
 					<MintActions
 						isConnected={mint.isConnected}
 						canMint={mint.canMint}
@@ -36,7 +108,7 @@ export default function MintPage() {
 						onMint={mint.handleMint}
 					/>
 				</Panel>
-			</MintLayout>
-		</>
+			</ActionTableLayout>
+		</FullScreenStack>
 	);
 }

--- a/app/src/samples/index.ts
+++ b/app/src/samples/index.ts
@@ -1,5 +1,3 @@
 // Barrel file: re-export all sample data
 export * from "./mintIssuer";
-// Future:
-// export * from "./mintStockClass";
-// export * from "./mintStakeholder";
+

--- a/app/src/samples/mintIssuer.ts
+++ b/app/src/samples/mintIssuer.ts
@@ -16,3 +16,32 @@ export const SAMPLE_ISSUER = {
 	addressCountry: "US",
 	postalCode: "10118",
 };
+
+// Samples for the post-mint stock class / stakeholder / issuance flows (used by the new dashboard forms)
+export const SAMPLE_STOCK_CLASS = {
+	name: "Series A Common",
+	class_type: "COMMON" as const,
+	default_id_prefix: "CS-A",
+	initial_shares_authorized: "1000000",
+	votes_per_share: "1",
+	price_per_share: { currency: "USD", amount: "4.20" },
+	seniority: "1",
+	comments: [],
+};
+
+export const SAMPLE_STAKEHOLDER = {
+	name: { legal_name: "Alex Palmer", first_name: "Alex", last_name: "Palmer" },
+	stakeholder_type: "INDIVIDUAL" as const,
+	current_relationship: "FOUNDER",
+	issuer_assigned_id: "",
+	comments: [],
+};
+
+export const SAMPLE_ISSUANCE = {
+	quantity: "100000",
+	share_price: { amount: "4.20", currency: "USD" },
+	stock_legend_ids: [],
+	custom_id: "CS-A-001",
+	security_law_exemptions: [],
+	comments: ["Founder stock issuance"],
+};

--- a/app/src/services/createStakeholder.ts
+++ b/app/src/services/createStakeholder.ts
@@ -1,0 +1,66 @@
+export interface StakeholderName {
+	legal_name: string;
+	first_name?: string;
+	last_name?: string;
+}
+
+export interface StakeholderData {
+	name: StakeholderName;
+	stakeholder_type: "INDIVIDUAL" | "INSTITUTION";
+	current_relationship: string;
+	issuer_assigned_id?: string;
+	comments?: string[];
+	// Optional contact fields can be added later for richer forms
+}
+
+export interface CreateStakeholderPayload {
+	issuerId: string;
+	data: StakeholderData;
+}
+
+export interface StakeholderResponse {
+	stakeholder: {
+		_id: string;
+		name: StakeholderName;
+		stakeholder_type: string;
+		current_relationship: string;
+		is_onchain_synced: boolean;
+		[key: string]: unknown;
+	};
+}
+
+export async function createStakeholder(payload: CreateStakeholderPayload): Promise<StakeholderResponse> {
+	const res = await fetch("/api/stakeholder/create", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
+
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(text || `Server returned ${res.status}`);
+	}
+
+	return res.json();
+}
+
+/**
+ * Register a stakeholder that the caller already created onchain via their own wallet.
+ * `id` is the UUID form of the bytes16 used in the onchain createStakeholder tx.
+ */
+export async function registerStakeholderOnchain(
+	payload: CreateStakeholderPayload & { id: string },
+): Promise<StakeholderResponse> {
+	const res = await fetch("/api/stakeholder/register-onchain", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
+
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(text || `Server returned ${res.status}`);
+	}
+
+	return res.json();
+}

--- a/app/src/services/createStockClass.ts
+++ b/app/src/services/createStockClass.ts
@@ -1,0 +1,63 @@
+export interface StockClassData {
+	name: string;
+	class_type: "COMMON" | "PREFERRED";
+	default_id_prefix: string;
+	initial_shares_authorized: string;
+	votes_per_share: string;
+	price_per_share: { currency: string; amount: string };
+	seniority: string;
+	comments?: string[];
+}
+
+export interface CreateStockClassPayload {
+	issuerId: string;
+	data: StockClassData;
+}
+
+export interface StockClassResponse {
+	stockClass: {
+		_id: string;
+		name: string;
+		class_type: string;
+		initial_shares_authorized: string;
+		price_per_share: { currency: string; amount: string };
+		is_onchain_synced: boolean;
+		[key: string]: unknown;
+	};
+}
+
+export async function createStockClass(payload: CreateStockClassPayload): Promise<StockClassResponse> {
+	const res = await fetch("/api/stock-class/create", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
+
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(text || `Server returned ${res.status}`);
+	}
+
+	return res.json();
+}
+
+/**
+ * Register a stock class that the caller already created onchain via their own wallet.
+ * `id` is the UUID form of the bytes16 used in the onchain createStockClass tx.
+ */
+export async function registerStockClassOnchain(
+	payload: CreateStockClassPayload & { id: string },
+): Promise<StockClassResponse> {
+	const res = await fetch("/api/stock-class/register-onchain", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
+
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(text || `Server returned ${res.status}`);
+	}
+
+	return res.json();
+}

--- a/app/src/services/createStockIssuance.ts
+++ b/app/src/services/createStockIssuance.ts
@@ -1,0 +1,69 @@
+export interface SharePrice {
+	amount: string;
+	currency: string;
+}
+
+export interface StockIssuanceData {
+	stakeholder_id: string;
+	stock_class_id: string;
+	quantity: string;
+	share_price: SharePrice;
+	stock_legend_ids?: string[];
+	custom_id?: string;
+	security_law_exemptions?: unknown[];
+	comments?: string[];
+}
+
+export interface CreateStockIssuancePayload {
+	issuerId: string;
+	data: StockIssuanceData;
+}
+
+export interface StockIssuanceResponse {
+	stockIssuance: {
+		id: string;
+		security_id: string;
+		stakeholder_id: string;
+		stock_class_id: string;
+		quantity: string;
+		share_price: SharePrice;
+		custom_id?: string;
+		[key: string]: unknown;
+	};
+}
+
+export async function createStockIssuance(payload: CreateStockIssuancePayload): Promise<StockIssuanceResponse> {
+	const res = await fetch("/api/transactions/issuance/stock", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
+
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(text || `Server returned ${res.status}`);
+	}
+
+	return res.json();
+}
+
+/**
+ * Register a stock issuance that the caller already submitted onchain via their own wallet.
+ * No id is required — the contract assigns issuance + security ids internally, and the poller
+ * writes the authoritative StockIssuance doc when it sees the event. This endpoint just
+ * validates the metadata so the UI can render optimistically until the poller catches up.
+ */
+export async function registerStockIssuanceOnchain(payload: CreateStockIssuancePayload): Promise<StockIssuanceResponse> {
+	const res = await fetch("/api/transactions/issuance/stock/register-onchain", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
+
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(text || `Server returned ${res.status}`);
+	}
+
+	return res.json();
+}

--- a/app/src/services/fetchHistoricalTransactions.ts
+++ b/app/src/services/fetchHistoricalTransactions.ts
@@ -1,0 +1,18 @@
+export interface HistoricalTransaction {
+  transactionType: string;
+  issuer: string;
+  transaction: any; // the populated transaction object
+}
+
+export async function fetchHistoricalTransactions(issuerId: string): Promise<HistoricalTransaction[]> {
+  if (!issuerId) return [];
+
+  const res = await fetch(`/api/historical-transactions/issuer-id/${encodeURIComponent(issuerId)}`);
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `Failed to fetch historical transactions (${res.status})`);
+  }
+
+  return res.json();
+}

--- a/app/src/services/registerIssuer.ts
+++ b/app/src/services/registerIssuer.ts
@@ -18,6 +18,7 @@ export interface RegisterIssuerPayload {
 	comments?: string[];
 	deployed_to: string;
 	tx_hash: string;
+	deployed_by?: string; // 0x admin wallet that initiated the mint tx
 }
 
 export interface IssuerResponse {

--- a/app/src/utils/lastMintedIssuer.ts
+++ b/app/src/utils/lastMintedIssuer.ts
@@ -1,0 +1,31 @@
+import type { IssuerResponse } from "../services/registerIssuer";
+
+const STORAGE_KEY = "tap_last_minted_issuer";
+
+export type LastMintedIssuer = Pick<IssuerResponse, "_id" | "legal_name" | "deployed_to" | "tx_hash">;
+
+export function saveLastMintedIssuer(issuer: IssuerResponse) {
+	try {
+		const toStore: LastMintedIssuer = {
+			_id: issuer._id,
+			legal_name: issuer.legal_name,
+			deployed_to: issuer.deployed_to,
+			tx_hash: issuer.tx_hash,
+		};
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(toStore));
+	} catch (e) {
+		console.warn("Failed to save last minted issuer to localStorage", e);
+	}
+}
+
+export function getLastMintedIssuer(): LastMintedIssuer | null {
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return null;
+		return JSON.parse(raw) as LastMintedIssuer;
+	} catch (e) {
+		console.warn("Failed to read last minted issuer from localStorage", e);
+		return null;
+	}
+}
+

--- a/app/src/utils/uuid.ts
+++ b/app/src/utils/uuid.ts
@@ -9,3 +9,36 @@ export function generateBytes16Id(): Hex {
 	const uuid = crypto.randomUUID();
 	return `0x${uuid.replace(/-/g, "")}` as Hex;
 }
+
+/**
+ * Convert a bytes16 hex string (0x + 32 hex chars, no dashes) back into a
+ * canonical lower-case UUID string with dashes. Used so the metadata _id stored
+ * in Mongo matches the bytes16 id we sent onchain (the poller converts the
+ * event's bytes16 back to this same UUID form).
+ */
+export function bytes16ToUuid(bytes16: string): string {
+	const hex = bytes16.startsWith("0x") ? bytes16.slice(2) : bytes16;
+	if (hex.length !== 32) {
+		throw new Error(`bytes16ToUuid: expected 32 hex chars, got ${hex.length}`);
+	}
+	return [
+		hex.slice(0, 8),
+		hex.slice(8, 12),
+		hex.slice(12, 16),
+		hex.slice(16, 20),
+		hex.slice(20, 32),
+	].join("-").toLowerCase();
+}
+
+/**
+ * Convert a UUID (with or without dashes) into a bytes16 hex string (0x + 32 hex chars).
+ * Idempotent: if `value` is already in 0x bytes16 form it is returned unchanged.
+ */
+export function uuidToBytes16(value: string): Hex {
+	const trimmed = value.startsWith("0x") ? value.slice(2) : value;
+	const hex = trimmed.replace(/-/g, "");
+	if (hex.length !== 32) {
+		throw new Error(`uuidToBytes16: expected 32 hex chars, got ${hex.length}`);
+	}
+	return `0x${hex.toLowerCase()}` as Hex;
+}

--- a/app/styled.d.ts
+++ b/app/styled.d.ts
@@ -35,5 +35,51 @@ declare module "styled-components" {
             none: string;
             main: string;
         };
+        spacing: {
+            0: string;
+            xs: string;
+            sm: string;
+            md: string;
+            lg: string;
+            xl: string;
+            "2xl": string;
+            "3xl": string;
+        };
+        fontWeights: {
+            normal: number;
+            medium: number;
+            semibold: number;
+            bold: number;
+        };
+        breakpoints: {
+            sm: string;
+            mobile: string;
+            tablet: string;
+            mintCollapse: string;
+        };
+        radii: {
+            none: string;
+            main: string;
+            sm: string;
+            md: string;
+        };
+        shadows: {
+            sm: string;
+            focus: string;
+        };
+        transitions: {
+            default: string;
+            spring: string;
+        };
+        maxWidths: {
+            main: string;
+            article: string;
+            h1: string;
+        };
+        zIndices: {
+            base: number;
+            dropdown: number;
+            modal: number;
+        };
     }
 }

--- a/app/wagmi.config.ts
+++ b/app/wagmi.config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
 	plugins: [
 		foundry({
 			project: "../chain",
-			include: ["CapTableFactory.sol/CapTableFactory.json"],
+			include: [
+				"CapTableFactory.sol/CapTableFactory.json",
+				"CapTable.sol/CapTable.json",
+			],
 		}),
 		react(),
 	],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
             CHAIN_ID: ${CHAIN_ID:-31337}
             PRIVATE_KEY: ${PRIVATE_KEY:-}
             PORT: 8293
+            POLLER_MAX_CONCURRENCY: ${POLLER_MAX_CONCURRENCY:-8}
         depends_on:
             mongodb:
                 condition: service_healthy

--- a/docs/src/pages/development/run-server.mdx
+++ b/docs/src/pages/development/run-server.mdx
@@ -83,6 +83,14 @@ A healthy boot logs roughly:
 
 ## Fixes
 
+<Callout type="info">
+If you don't see changes that you pushed in your code on the app or in the server, rebuild docker containers (since they don't have hot reloading).
+
+```bash
+docker compose up -d --build app server
+```
+</Callout>
+
 | Symptom | Check |
 | --- | --- |
 | `EADDRINUSE` | Another process uses `PORT=8293`. |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,14 +211,14 @@ importers:
   ocf:
     dependencies:
       date-fns:
-        specifier: ^2.30.0
+        specifier: ^2.28.0
         version: 2.30.0
     devDependencies:
       '@actions/core':
-        specifier: ^1.11.1
+        specifier: ^1.6.0
         version: 1.11.1
       '@actions/github':
-        specifier: ^5.1.1
+        specifier: ^5.0.0
         version: 5.1.1
       '@adobe/jsonschema2md':
         specifier: ^6.1.4
@@ -227,22 +227,22 @@ importers:
         specifier: ^9.0.13
         version: 9.0.13
       '@types/jest':
-        specifier: ^27.5.2
+        specifier: ^27.4.0
         version: 27.5.2
       '@types/node':
-        specifier: ^17.0.45
+        specifier: ^17.0.18
         version: 17.0.45
       '@types/yargs':
-        specifier: ^17.0.35
+        specifier: ^17.0.10
         version: 17.0.35
       ajv:
-        specifier: ^8.18.0
+        specifier: ^8.9.0
         version: 8.18.0
       ajv-formats:
         specifier: ^2.1.1
         version: 2.1.1(ajv@8.18.0)
       fs-extra:
-        specifier: ^10.1.0
+        specifier: ^10.0.1
         version: 10.1.0
       husky:
         specifier: ^7.0.4
@@ -251,10 +251,10 @@ importers:
         specifier: ^27.5.1
         version: 27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@17.0.45)(typescript@4.9.5))(utf-8-validate@5.0.10)
       lint-staged:
-        specifier: ^12.5.0
+        specifier: ^12.1.5
         version: 12.5.0
       markdown-table:
-        specifier: ^3.0.4
+        specifier: ^3.0.2
         version: 3.0.4
       prettier:
         specifier: 2.5.1
@@ -263,16 +263,16 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
       ts-jest:
-        specifier: ^27.1.5
+        specifier: ^27.1.3
         version: 27.1.5(@babel/core@7.28.4)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.28.4))(jest@27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@17.0.45)(typescript@4.9.5))(utf-8-validate@5.0.10))(typescript@4.9.5)
       ts-node:
-        specifier: ^10.9.2
+        specifier: ^10.5.0
         version: 10.9.2(@types/node@17.0.45)(typescript@4.9.5)
       typescript:
-        specifier: ^4.9.5
+        specifier: ^4.5.5
         version: 4.9.5
       yargs:
-        specifier: ^17.7.2
+        specifier: ^17.3.1
         version: 17.7.2
 
 packages:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,14 +211,14 @@ importers:
   ocf:
     dependencies:
       date-fns:
-        specifier: ^2.28.0
+        specifier: ^2.30.0
         version: 2.30.0
     devDependencies:
       '@actions/core':
-        specifier: ^1.6.0
+        specifier: ^1.11.1
         version: 1.11.1
       '@actions/github':
-        specifier: ^5.0.0
+        specifier: ^5.1.1
         version: 5.1.1
       '@adobe/jsonschema2md':
         specifier: ^6.1.4
@@ -227,22 +227,22 @@ importers:
         specifier: ^9.0.13
         version: 9.0.13
       '@types/jest':
-        specifier: ^27.4.0
+        specifier: ^27.5.2
         version: 27.5.2
       '@types/node':
-        specifier: ^17.0.18
+        specifier: ^17.0.45
         version: 17.0.45
       '@types/yargs':
-        specifier: ^17.0.10
+        specifier: ^17.0.35
         version: 17.0.35
       ajv:
-        specifier: ^8.9.0
+        specifier: ^8.18.0
         version: 8.18.0
       ajv-formats:
         specifier: ^2.1.1
         version: 2.1.1(ajv@8.18.0)
       fs-extra:
-        specifier: ^10.0.1
+        specifier: ^10.1.0
         version: 10.1.0
       husky:
         specifier: ^7.0.4
@@ -251,10 +251,10 @@ importers:
         specifier: ^27.5.1
         version: 27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@17.0.45)(typescript@4.9.5))(utf-8-validate@5.0.10)
       lint-staged:
-        specifier: ^12.1.5
+        specifier: ^12.5.0
         version: 12.5.0
       markdown-table:
-        specifier: ^3.0.2
+        specifier: ^3.0.4
         version: 3.0.4
       prettier:
         specifier: 2.5.1
@@ -263,16 +263,16 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
       ts-jest:
-        specifier: ^27.1.3
+        specifier: ^27.1.5
         version: 27.1.5(@babel/core@7.28.4)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.28.4))(jest@27.5.1(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@17.0.45)(typescript@4.9.5))(utf-8-validate@5.0.10))(typescript@4.9.5)
       ts-node:
-        specifier: ^10.5.0
+        specifier: ^10.9.2
         version: 10.9.2(@types/node@17.0.45)(typescript@4.9.5)
       typescript:
-        specifier: ^4.5.5
+        specifier: ^4.9.5
         version: 4.9.5
       yargs:
-        specifier: ^17.3.1
+        specifier: ^17.7.2
         version: 17.7.2
 
 packages:
@@ -1139,9 +1139,11 @@ packages:
 
   '@metamask/sdk-analytics@0.0.5':
     resolution: {integrity: sha512-fDah+keS1RjSUlC8GmYXvx6Y26s3Ax1U9hGpWb6GSY5SAdmTSIqp2CvYy6yW0WgLhnYhW+6xERuD0eVqV63QIQ==}
+    deprecated: No longer maintained, superseded by @metamask/connect-analytics
 
   '@metamask/sdk-communication-layer@0.33.1':
     resolution: {integrity: sha512-0bI9hkysxcfbZ/lk0T2+aKVo1j0ynQVTuB3sJ5ssPWlz+Z3VwveCkP1O7EVu1tsVVCb0YV5WxK9zmURu2FIiaA==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
     peerDependencies:
       cross-fetch: ^4.0.0
       eciesjs: '*'
@@ -1151,9 +1153,11 @@ packages:
 
   '@metamask/sdk-install-modal-web@0.32.1':
     resolution: {integrity: sha512-MGmAo6qSjf1tuYXhCu2EZLftq+DSt5Z7fsIKr2P+lDgdTPWgLfZB1tJKzNcwKKOdf6q9Qmmxn7lJuI/gq5LrKw==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/sdk@0.33.1':
     resolution: {integrity: sha512-1mcOQVGr9rSrVcbKPNVzbZ8eCl1K0FATsYH3WJ/MH4WcZDWGECWrXJPNMZoEAkLxWiMe8jOQBumg2pmcDa9zpQ==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/superstruct@3.2.1':
     resolution: {integrity: sha512-fLgJnDOXFmuVlB38rUN5SmU7hAFQcCjrg3Vrxz67KTY7YHFnSNEKvX4avmEBdOI0yTCxZjwMCFEqsC8k2+Wd3g==}
@@ -10119,7 +10123,7 @@ snapshots:
   '@jest/console@27.5.1':
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -10132,7 +10136,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -10166,14 +10170,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       jest-mock: 27.5.1
 
   '@jest/fake-timers@27.5.1':
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -10191,7 +10195,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -10260,7 +10264,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       '@types/yargs': 16.0.11
       chalk: 4.1.2
 
@@ -12351,13 +12355,13 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
 
   '@types/geojson@7946.0.16': {}
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
 
   '@types/hast@3.0.4':
     dependencies:
@@ -17317,7 +17321,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -17415,7 +17419,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -17430,7 +17434,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       jest-mock: 27.5.1
       jest-util: 27.5.1
 
@@ -17440,7 +17444,7 @@ snapshots:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.9
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -17459,7 +17463,7 @@ snapshots:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -17502,7 +17506,7 @@ snapshots:
   jest-mock@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
 
   jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
     optionalDependencies:
@@ -17538,7 +17542,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -17589,7 +17593,7 @@ snapshots:
 
   jest-serializer@27.5.1:
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       graceful-fs: 4.2.11
 
   jest-snapshot@27.5.1:
@@ -17622,7 +17626,7 @@ snapshots:
   jest-util@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -17641,7 +17645,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -17649,7 +17653,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 24.6.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 

--- a/server/chain-operations/transactionPoller.ts
+++ b/server/chain-operations/transactionPoller.ts
@@ -79,6 +79,10 @@ export const stopEventProcessing = async () => {
 
 export const pollingSleepTime = 20_000;
 
+// Max number of issuers processed in parallel per cycle.
+// The poller is slated to be replaced by a proper indexer, so this is the main (and only) tuning knob we keep.
+const POLLER_MAX_CONCURRENCY = Number.parseInt(process.env.POLLER_MAX_CONCURRENCY || "5", 10) || 5;
+
 interface IEventProcessing {
     finalizedOnly: boolean;
     useConn?: Connection;
@@ -91,14 +95,19 @@ export const startEventProcessing = async ({ finalizedOnly, useConn }: IEventPro
     const dbConn = useConn || (await connectDB());
     while (_keepProcessing) {
         const issuers = await readAllIssuers();
+        const activeIssuers: any[] = issuers.filter((issuer: any) => issuer.deployed_to);
 
-        console.log(`Processing synchronously for ${issuers.length} issuers at ${Date()}`);
-        for (const issuer of issuers) {
-            if (issuer.deployed_to) {
+        console.log(`Processing for ${activeIssuers.length} issuers at ${Date()}`);
+
+        await runWithConcurrency(activeIssuers, POLLER_MAX_CONCURRENCY, async (issuer: any) => {
+            try {
                 const { contract, provider, libraries } = await getIssuerContract(issuer);
                 await processEvents(dbConn, contract, provider, issuer, libraries.txHelper, finalizedOnly);
+            } catch (err) {
+                console.error(`Poller error for issuer ${issuer._id}:`, err);
             }
-        }
+        });
+
         await sleep(pollingSleepTime);
     }
     _finishedProcessing = true;
@@ -118,7 +127,11 @@ const getRetryOptions = (action: string, options?: RetryOptions): RetryOptions =
     };
 };
 
-const processEvents = async (dbConn, contract, provider, issuer, txHelper, finalizedOnly, maxBlocks = 500, maxEvents = 250) => {
+// maxBlocks is the per-cycle event-query window. Each cycle is bounded by `maxEvents` regardless,
+// so a large window mostly helps drain a backlog quickly when the issuer is far behind chain head.
+// 5000 is a pragmatic value for fast chains (e.g. Plume); the original 500 was leaving the poller
+// stuck grinding through old blocks on busy networks.
+const processEvents = async (dbConn, contract, provider, issuer, txHelper, finalizedOnly, maxBlocks = 5000, maxEvents = 250) => {
     /*
     We process up to `maxEvents` across `maxBlocks` to ensure our transaction sizes dont get too big and bog down our db
     */
@@ -147,7 +160,6 @@ const processEvents = async (dbConn, contract, provider, issuer, txHelper, final
         return;
     }
 
-    // console.log(" processing from", { startBlock, endBlock });
     let events: QueuedEvent[] = [];
 
     const contractEvents: EventLog[] = await pRetry(
@@ -211,11 +223,9 @@ const issuerDeployed = async (issuerId, receipt, contract, dbConn) => {
 
 const persistEvents = async (issuerId, events: QueuedEvent[]) => {
     // Persist all the necessary changes for each event gathered in process events
-    // console.log(`${events.length} events to process for issuerId ${issuerId}`);
     for (const event of events) {
         const { type, data, timestamp } = event;
         const txHandleFunc = txFuncs[type];
-        // console.log("persistEvent: ", {type, data, timestamp});
         if (txHandleFunc) {
             await txHandleFunc(data, issuerId, timestamp);
             continue;
@@ -256,3 +266,23 @@ export const trimEvents = (origEvents: QueuedEvent[], maxEvents, endBlock) => {
 const updateLastProcessed = async (issuerId, lastProcessedBlock) => {
     return updateIssuerById(issuerId, { last_processed_block: lastProcessedBlock });
 };
+
+async function runWithConcurrency<T>(items: T[], concurrency: number, worker: (item: T) => Promise<void>): Promise<void> {
+    const queue = [...items];
+    const runNext = async (): Promise<void> => {
+        if (queue.length === 0) return;
+        const item = queue.shift()!;
+        try {
+            await worker(item);
+        } finally {
+            await runNext();
+        }
+    };
+
+    const actualConcurrency = Math.min(concurrency, items.length);
+    const workers: Promise<void>[] = [];
+    for (let i = 0; i < actualConcurrency; i++) {
+        workers.push(runNext());
+    }
+    await Promise.all(workers);
+}

--- a/server/db/objects/Issuer.js
+++ b/server/db/objects/Issuer.js
@@ -19,6 +19,7 @@ const IssuerSchema = new mongoose.Schema(
         comments: [String],
         deployed_to: String, // Address of its CapTable
         tx_hash: String,
+        deployed_by: String, // Admin wallet address (0x) that called factory.createCapTable at mint time
         last_processed_block: { type: Number, default: null },
         is_manifest_created: { type: Boolean, default: false },
     },

--- a/server/routes/issuer.js
+++ b/server/routes/issuer.js
@@ -5,6 +5,8 @@ import issuerSchema from "../../ocf/schema/objects/Issuer.schema.json" with { ty
 import deployCapTable from "../chain-operations/deployCapTable.js";
 import { createIssuer } from "../db/operations/create.js";
 import { countIssuers, readIssuerById } from "../db/operations/read.js";
+import { find } from "../db/operations/atomic.ts";
+import Issuer from "../db/objects/Issuer.js";
 import { convertBytes16ToUUID, convertUUIDToBytes16 } from "../utils/convertUUID.js";
 import validateInputAgainstOCF from "../utils/validateInputAgainstSchema.js";
 
@@ -79,7 +81,7 @@ issuer.post("/create", async (req, res) => {
 // Register an externally-deployed cap table (e.g. from the frontend wallet flow)
 issuer.post("/register", async (req, res) => {
     try {
-        const { id: bytes16Id, deployed_to, tx_hash, ...ocfFields } = req.body;
+        const { id: bytes16Id, deployed_to, tx_hash, deployed_by, ...ocfFields } = req.body;
 
         if (!deployed_to || !tx_hash) {
             return res.status(400).send("deployed_to and tx_hash are required");
@@ -104,6 +106,7 @@ issuer.post("/register", async (req, res) => {
             ...incomingIssuerToValidate,
             deployed_to,
             tx_hash,
+            ...(deployed_by && { deployed_by }),
         };
 
         const issuerRecord = await createIssuer(incomingIssuerForDB);
@@ -111,6 +114,36 @@ issuer.post("/register", async (req, res) => {
         console.log("✅ | Issuer registered offchain:", issuerRecord);
 
         res.status(200).send({ issuer: issuerRecord });
+    } catch (error) {
+        console.error(error);
+        res.status(500).send(`${error}`);
+    }
+});
+
+// GET full issuer document (the actual OCF + deployed_to etc. saved at mint/register time).
+// Used by the /manage/cap-table page to hydrate the full issuer record from a URL ?issuerId=.
+issuer.get("/full/:id", async (req, res) => {
+    try {
+        const { id } = req.params;
+        const issuerDoc = await readIssuerById(id);
+        if (!issuerDoc) {
+            return res.status(404).send("Issuer not found");
+        }
+        res.status(200).send(issuerDoc);
+    } catch (error) {
+        console.error(error);
+        res.status(500).send(`${error}`);
+    }
+});
+
+// List all issuers deployed by a given admin wallet address (the ones this UI cares about)
+issuer.get("/by-deployer/:address", async (req, res) => {
+    try {
+        const addr = req.params.address;
+        if (!addr) return res.status(400).send("address required");
+        // Match case-insensitively on the stored address
+        const issuers = await find(Issuer, { deployed_by: new RegExp(`^${addr}$`, "i") });
+        res.status(200).send({ issuers, count: issuers.length });
     } catch (error) {
         console.error(error);
         res.status(500).send(`${error}`);

--- a/server/routes/stakeholder.js
+++ b/server/routes/stakeholder.js
@@ -126,6 +126,45 @@ stakeholder.post("/create", async (req, res) => {
     }
 });
 
+// Register a stakeholder that the caller already created onchain from their own wallet.
+// The caller MUST supply `id` (the UUID form of the bytes16 used in their createStakeholder tx).
+// We persist it as `_id` so the poller's update-by-_id lookup matches when it processes the
+// StakeholderCreated event.
+stakeholder.post("/register-onchain", async (req, res) => {
+    const { data, issuerId, id } = req.body;
+
+    if (!id) {
+        return res.status(400).send("id is required (UUID form of the bytes16 used in the onchain createStakeholder tx)");
+    }
+
+    try {
+        const issuer = await readIssuerById(issuerId);
+
+        const incomingStakeholderToValidate = {
+            id,
+            object_type: "STAKEHOLDER",
+            ...data,
+        };
+
+        const incomingStakeholderForDB = {
+            ...incomingStakeholderToValidate,
+            _id: id,
+            issuer: issuer._id,
+        };
+
+        await validateInputAgainstOCF(incomingStakeholderToValidate, stakeholderSchema);
+
+        const stakeholder = await createStakeholder(incomingStakeholderForDB);
+
+        console.log("✅ | Stakeholder metadata registered for onchain id:", id);
+
+        res.status(200).send({ stakeholder });
+    } catch (error) {
+        console.error(error);
+        res.status(500).send(`${error}`);
+    }
+});
+
 stakeholder.post("/add-wallet", async (req, res) => {
     const { contract } = req;
     const { id, wallet } = req.body;

--- a/server/routes/stockClass.js
+++ b/server/routes/stockClass.js
@@ -57,11 +57,51 @@ stockClass.post("/create", async (req, res) => {
             issuer: issuer._id,
         };
         await validateInputAgainstOCF(incomingStockClassToValidate, stockClassSchema);
+
         await convertAndReflectStockClassOnchain(contract, incomingStockClassForDB);
 
         const stockClass = await createStockClass(incomingStockClassForDB);
 
         console.log("✅ | Stock Class created offchain:", stockClass);
+
+        res.status(200).send({ stockClass });
+    } catch (error) {
+        console.error(error);
+        res.status(500).send(`${error}`);
+    }
+});
+
+// Register a stock class that the caller already created onchain from their own wallet.
+// The caller MUST supply `id` (the UUID form of the bytes16 used in their onchain tx).
+// We persist it as `_id` so the poller's update-by-_id lookup matches when it processes
+// the StockClassCreated event.
+stockClass.post("/register-onchain", async (req, res) => {
+    const { data, issuerId, id } = req.body;
+
+    if (!id) {
+        return res.status(400).send("id is required (UUID form of the bytes16 used in the onchain createStockClass tx)");
+    }
+
+    try {
+        const issuer = await readIssuerById(issuerId);
+
+        const incomingStockClassToValidate = {
+            id,
+            object_type: "STOCK_CLASS",
+            ...data,
+        };
+
+        const incomingStockClassForDB = {
+            ...incomingStockClassToValidate,
+            _id: id,
+            issuer: issuer._id,
+        };
+
+        await validateInputAgainstOCF(incomingStockClassToValidate, stockClassSchema);
+
+        const stockClass = await createStockClass(incomingStockClassForDB);
+
+        console.log("✅ | Stock Class metadata registered for onchain id:", id);
 
         res.status(200).send({ stockClass });
     } catch (error) {

--- a/server/routes/transactions.js
+++ b/server/routes/transactions.js
@@ -54,6 +54,35 @@ transactions.post("/issuance/stock", async (req, res) => {
     }
 });
 
+// Register a stock issuance that the caller already issued onchain from their own wallet.
+// We do NOT submit onchain. We don't persist a StockIssuance doc here either — the poller
+// writes the authoritative doc when it sees the TxCreated event. We just validate + return
+// the prepared OCF shape so the UI can render optimistically until the poller catches up.
+transactions.post("/issuance/stock/register-onchain", async (req, res) => {
+    const { issuerId, data } = req.body;
+
+    try {
+        await readIssuerById(issuerId);
+
+        const incomingStockIssuance = {
+            id: uuid(), // for OCF Validation only (real id comes from onchain event)
+            security_id: uuid(), // for OCF Validation only (real one comes from onchain event)
+            date: new Date().toISOString().slice(0, 10),
+            object_type: "TX_STOCK_ISSUANCE",
+            ...data,
+        };
+
+        await validateInputAgainstOCF(incomingStockIssuance, stockIssuanceSchema);
+
+        console.log("✅ | Stock issuance metadata accepted (onchain by caller's wallet)");
+
+        res.status(200).send({ stockIssuance: incomingStockIssuance });
+    } catch (error) {
+        console.error(error);
+        res.status(500).send(`${error}`);
+    }
+});
+
 transactions.post("/transfer/stock", async (req, res) => {
     const { contract } = req;
     const { issuerId, data } = req.body;


### PR DESCRIPTION
## What?
  - New `/manage` direct-wallet UI for cap-table ops (create stock class, create stakeholder, issue stock) — signs from the connected admin wallet instead of the server's operator key.
  - Server `/register-onchain` route convention + `Issuer.deployed_by` field + `/by-deployer/:address` and `/full/:id` read endpoints.
  - Poller simplified to round-robin + concurrency only; slated for indexer replacement. `maxBlocks` raised 500 → 5000.

  ## Why?
  - Move cap-table operations off the server's operator key and onto the connected admin wallet — proper attribution, no shared signer for governance.
  - Keep the poller boring (and small) until the indexer lands; previous prioritization machinery was effort we'd throw away.

  ## Testing
  - [x ] Mint a new cap table from a connected wallet; verify it appears in `/manage` via the "Sync by my wallet" button (validates `deployed_by`).
  - [ x] On `/manage/cap-table`, create a stock class via the wallet; success modal renders with a real tx hash (validates effect-driven hash watcher).
  - [ x] Issue shares to shareholders, create multiple shareholders, share issues on top of previous issued shares and check that everything adds up correctly
<img width="2076" height="1315" alt="Screenshot 2026-05-25 at 4 45 07 PM" src="https://github.com/user-attachments/assets/6571586f-be1a-41f8-beff-2cebc808e8a4" />
<img width="4096" height="2595" alt="image" src="https://github.com/user-attachments/assets/4921d9a6-d3f4-4331-ba59-16464fc6fc97" />
