### PR TITLE
docs: refresh warp and agent docs for the cap-table frontend

### DIFF
--- a/.grok/skills/review/SKILL.md
+++ b/.grok/skills/review/SKILL.md
@@ -54,11 +54,11 @@ Everything that follows assumes those docs are the authoritative spec. Do not du
 For each touched domain, apply the matching rule set from the docs:
 
 - `chain/src/**/*.sol` or `chain/test/**/*.sol`: NatSpec, custom errors, events, SPDX 0.8.30, via-ir compatibility, `onlyOperator`/`onlyAdmin` correctness, snake_case struct fields, and that new logic is covered by both unit **and** invariant tests.
-- `server/**`: OCF validation via `validateInputAgainstOCF`, conversion helpers (`convertUUIDToBytes16`, `toScaledBigNumber`), `withGlobalTransaction` for atomic multi-doc writes, poller/state-machine consistency.
-- `app/src/**`: every rule in `app/WARP.md` (file naming, theme tokens only, transient `$` props, allowed cubic-beziers, no new fontWeights).
+- `server/**`: OCF validation via `validateInputAgainstSchema`, conversion helpers (`convertUUIDToBytes16`, `toScaledBigNumber`), `withGlobalTransaction` for atomic multi-doc writes, poller/state-machine consistency.
+- `app/src/**`: every rule in `app/WARP.md` — file naming (lowercase styled vs PascalCase logic), theme tokens only (no hard-coded colors/sizes/breakpoints/transitions), transient `$` props, `theme.transitions.*` / `theme.breakpoints.*` over raw values, and no fontWeights beyond `normal`/`medium`/`semibold`/`bold`. For onchain frontend code: `src/generated.ts` is generated (never hand-edited; regenerate via `pnpm --filter tap-app generate:wagmi` after ABI changes), write-side `1e10` scaling on `quantity`/`share_price`, UUID↔bytes16 conversion via `src/utils/uuid.ts`, and correct use of direct-wallet hooks (`useDirect*` + `registerXxxOnchain`) vs server-signed `create*` services.
 - `docs/src/pages/**/*.mdx`: every bullet in the "Documentation DX conventions" section of root `WARP.md` and the bar in `DOCS_AUDIT.md`.
 
-Run the actual commands appropriate to the scope: `pnpm lint`, `pnpm typecheck`, `pnpm test`, `make test`, `make test-invariant`, `make security`, `pnpm docs:build`. A broken build, lint, or relevant test = automatic FAIL.
+Run the actual commands appropriate to the scope: `pnpm lint`, `pnpm typecheck`, `pnpm test`, `make test`, `make test-invariant`, `make security`, `pnpm docs:build`, `pnpm app:build`. When frontend contract bindings or wallet code changed, also run `pnpm --filter tap-app generate:wagmi` and confirm `src/generated.ts` is in sync. A broken build, lint, or relevant test = automatic FAIL.
 
 ### Phase C — Architecture invariants
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in the Transfer Agent Protocol (TAP) Cap Table monorepo.
+
+The canonical, always-up-to-date agent guidance for this repo lives in the `WARP.md` files. Read them before making changes:
+
+- [`WARP.md`](./WARP.md) — monorepo architecture, development commands, important patterns, security tooling, and Git workflow.
+- [`app/WARP.md`](./app/WARP.md) — frontend (`tap-app`) conventions: styled-components, wallet/web3 (wagmi + viem + Reown AppKit), generated contract hooks, and onchain data conventions.
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — branch, commit, and pull-request conventions.
+
+Quick reminders:
+
+- Package manager is **pnpm** (this is a pnpm workspace monorepo) — do not use `npm` or `yarn`.
+- Never commit directly to `main`; branch from it and open a PR. PR titles follow Conventional Commits.
+- The blockchain is the source of truth; the off-chain DB mirrors it via the event poller.
+- Don't hand-edit `app/src/generated.ts` — regenerate it with `pnpm --filter tap-app generate:wagmi`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in the Transfer Agent Protocol (TAP) Cap Table monorepo.
+
+The canonical, always-up-to-date guidance for this repo lives in the `WARP.md` files (and applies equally to Claude Code). Read them before making changes:
+
+- [`WARP.md`](./WARP.md) — monorepo architecture, development commands, important patterns, security tooling, and Git workflow.
+- [`app/WARP.md`](./app/WARP.md) — frontend (`tap-app`) conventions: styled-components, wallet/web3 (wagmi + viem + Reown AppKit), generated contract hooks, and onchain data conventions.
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — branch, commit, and pull-request conventions.
+
+Quick reminders:
+
+- Package manager is **pnpm** (this is a pnpm workspace monorepo) — do not use `npm` or `yarn`.
+- Never commit directly to `main`; branch from it and open a PR. PR titles follow Conventional Commits.
+- The blockchain is the source of truth; the off-chain DB mirrors it via the event poller.
+- Don't hand-edit `app/src/generated.ts` — regenerate it with `pnpm --filter tap-app generate:wagmi`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a **pnpm monorepo**:
 
 ```
 tap-cap-table/
-├── app/        # Next.js frontend
+├── app/        # Next.js frontend (landing + cap-table dApp)
 ├── server/     # Express API server
 ├── chain/      # Solidity smart contracts (Foundry)
 ├── docs/       # Nextra documentation site
@@ -34,12 +34,12 @@ pnpm docker:up              # Start MongoDB, server, and app
 
 This spins up three services via Docker:
 **Server** http://localhost:8293
-**App** http://localhost:3000
+**App** http://localhost:3000 — landing page + wallet-based cap-table minting (`/mint`) and management (`/manage`)
 **MongoDB** localhost:27017
 
 Then go read official [docs](https://docs.transferagentprotocol.xyz/)
 
-> **Environment**: Copy `.env.example` to `.env` and fill in `PRIVATE_KEY`, `RPC_URL`, `CHAIN_ID`, and the `NEXT_PUBLIC_*` variables for the frontend. For Plume Mainnet, set `CHAIN_ID=98866` and `RPC_URL=https://rpc.plume.org`.
+> **Environment**: Copy `.env.example` to `.env` and fill in `PRIVATE_KEY`, `RPC_URL`, `CHAIN_ID`, and the `NEXT_PUBLIC_*` variables for the frontend (including `NEXT_PUBLIC_REOWN_PROJECT_ID` from [cloud.reown.com](https://cloud.reown.com) for wallet connection). For Plume Mainnet, set `CHAIN_ID=98866` and `RPC_URL=https://rpc.plume.org`.
 
 ### Scripts
 

--- a/WARP.md
+++ b/WARP.md
@@ -284,7 +284,7 @@ pnpm app:build
 pnpm app:start
 ```
 
-The frontend is a Next.js app in the `app/` workspace using styled-components v6.
+The frontend is a Next.js 16 app in the `app/` workspace using styled-components v6, with wallet/onchain support via wagmi, viem, Reown AppKit, and TanStack Query. It serves both the landing page and the wallet-based cap-table minting/management UI (`/mint`, `/manage`). Generated contract hooks live in `app/src/generated.ts` — regenerate them with `pnpm --filter tap-app generate:wagmi` after contract ABI changes. See [`app/WARP.md`](app/WARP.md) for full frontend conventions.
 
 ### Deployment
 

--- a/app/README.md
+++ b/app/README.md
@@ -1,6 +1,9 @@
 # TAP Frontend
 
-Next.js frontend for the [Transfer Agent Protocol](https://transferagentprotocol.xyz).
+Next.js frontend for the [Transfer Agent Protocol](https://transferagentprotocol.xyz). It serves the public landing page and a wallet-based dApp for minting and managing onchain cap tables:
+
+- `/mint` — deploy a new cap table from the connected admin wallet
+- `/manage` — list and manage cap tables your wallet has deployed
 
 ## Development
 
@@ -10,12 +13,17 @@ pnpm app:dev
 
 # Or from this directory
 pnpm dev
+
+# Regenerate contract hooks (src/generated.ts) after a chain ABI change
+pnpm generate:wagmi
 ```
 
 ## Tech Stack
 
-- Next.js (Pages Router)
-- styled-components
+- Next.js 16 (Pages Router), React 19
+- styled-components v6
+- wagmi + viem + Reown AppKit (wallet connection)
+- TanStack Query (data fetching)
 - IBM Plex Mono font
 
-See the root [CONTRIBUTING.md](../CONTRIBUTING.md) for contribution guidelines.
+See [`WARP.md`](./WARP.md) for frontend conventions and the root [CONTRIBUTING.md](../CONTRIBUTING.md) for contribution guidelines.

--- a/app/WARP.md
+++ b/app/WARP.md
@@ -4,60 +4,96 @@ This file provides guidance to WARP (warp.dev) when working with code in this re
 
 ## Overview
 
-Transfer Agent Protocol (TAP) frontend and landing page - a Next.js site using styled-components for styling.
+Transfer Agent Protocol (TAP) frontend — the `tap-app` workspace. It is both the public landing page and a wallet-based dApp for minting and managing onchain cap tables. Key screens:
+
+- `/` — landing page
+- `/mint` — deploy a new cap table from the connected admin wallet
+- `/manage` — hub listing cap tables the connected wallet has deployed
+- `/manage/cap-table?issuerId=...` — full dashboard to create stock classes, stakeholders, and issuances for one cap table
+
+It talks to the TAP API server (proxied at `/api/*`) and directly to the `CapTable` / `CapTableFactory` contracts via the user's wallet. See the root [`WARP.md`](../WARP.md) for the full hybrid onchain/offchain architecture.
 
 ## Commands
 
+Run from `app/` (root workspace aliases on the right):
+
 ```bash
-# Development server
-pnpm dev
-
-# Production build (includes sitemap generation)
-pnpm build
-
-# Start production server
-pnpm start
-
-# Type checking
-pnpm typecheck
-
-# Linting
-pnpm lint
+pnpm dev              # Dev server                 (root: pnpm app:dev)
+pnpm build            # Production build + sitemap  (root: pnpm app:build)
+pnpm start            # Serve production build      (root: pnpm app:start)
+pnpm typecheck        # tsc --noEmit
+pnpm lint             # eslint src/
+pnpm eslint <paths>   # eslint --fix
+pnpm generate:wagmi   # Regenerate src/generated.ts from chain ABIs
 ```
+
+`pnpm build` runs `next build` then `next-sitemap` (postbuild). The root `pnpm typecheck` includes this app via `typecheck:app`.
 
 ## Architecture
 
 ### Tech Stack
-- **Framework**: Next.js (Pages Router)
-- **Styling**: styled-components v6 with ThemeProvider
-- **Font**: IBM Plex Mono (loaded via next/font)
-- **React**: v19
+- **Framework**: Next.js 16 (Pages Router), React 19
+- **Styling**: styled-components v6 with `ThemeProvider`
+- **Wallet / web3**: wagmi v3 + viem v2, with Reown AppKit (`@reown/appkit`, `@reown/appkit-adapter-wagmi`) for the connect modal
+- **Data fetching**: TanStack Query (`@tanstack/react-query`)
+- **Font**: IBM Plex Mono (loaded via `next/font`)
+- **Sitemap**: `next-sitemap` (postbuild)
 
 ### Project Structure
-- `src/pages/` - Next.js pages (`_app.tsx` wraps all pages with theme/layout)
-- `src/components/` - Reusable styled components
-  - `theme.tsx` - Design tokens (colors, fontSizes, lineHeights, borderRadius)
-  - `typography.tsx` - Text components (H1, H2, H3, P, etc.)
-  - `layout.tsx` - Main layout wrapper with Navbar and Footer
-  - `wrappers.tsx` - Layout containers
+- `src/pages/` — Next.js pages. `_app.tsx` wires up providers; `_document.tsx`; `index.tsx` (landing); `mint.tsx`; `manage/index.tsx` and `manage/cap-table.tsx`.
+- `src/components/` — styled components (lowercase files) and React components (PascalCase), e.g. `CapTableDashboard.tsx`, `IssueStockForm.tsx`, `Navbar.tsx`.
+- `src/config/` — runtime + web3 config: `wagmi.ts` (AppKit + `WagmiAdapter`, networks), `Web3Provider.tsx`, `contracts.ts` (addresses, `DECIMAL_SCALE`, re-exported generated hooks).
+- `src/hooks/` — wagmi hooks for onchain writes: `useMintIssuer`, `useDirectCreateStockClass`, `useDirectCreateStakeholder`, `useDirectIssueStock`, plus `useCapTableManager` (server flow + holdings).
+- `src/services/` — typed `fetch` wrappers around the API server (`registerIssuer`, `createStockClass`, `createStakeholder`, `createStockIssuance`, `fetchHistoricalTransactions`).
+- `src/utils/` — `uuid.ts` (UUID↔bytes16 helpers), `lastMintedIssuer.ts` (localStorage).
+- `src/samples/` — sample/seed payloads for the mint flow.
+- `src/generated.ts` — **generated** wagmi contract hooks (do not edit; see Contract bindings).
+- `styled.d.ts` — styled-components theme type augmentation.
+
+### Wallet & Web3 Integration
+- Provider nesting in `src/pages/_app.tsx`: `Web3Provider` → `ThemeProvider` (+ `GlobalStyle`) → `CapTableMenuProvider` → `Layout`.
+- `src/config/Web3Provider.tsx` wraps `WagmiProvider` (config from `wagmiAdapter.wagmiConfig`) and `QueryClientProvider`.
+- `src/config/wagmi.ts` builds the Reown `WagmiAdapter` and calls `createAppKit` (guarded to the client only). Supported networks: **Plume Mainnet (98866)**, **Plume Testnet (98867)**, **Anvil (31337)**. Requires `NEXT_PUBLIC_REOWN_PROJECT_ID`.
+
+### Contract Bindings (wagmi codegen)
+- `src/generated.ts` is produced by `wagmi.config.ts` (`@wagmi/cli` `foundry` plugin reading Foundry artifacts from `../chain` + the `react` plugin). **Do not hand-edit it.**
+- Regenerate after contract ABI changes: `pnpm generate:wagmi` (from `app/`) or `pnpm --filter tap-app generate:wagmi` (from root). The contracts must be built first (`pnpm setup`, or `forge build` in `chain/`).
+- Consume hooks via `src/config/contracts.ts` (which re-exports the ones the app uses) or import from `../generated` directly.
+
+### Onchain Data Conventions
+These mirror the rules in the root `WARP.md` — keep them in sync.
+- **Fixed-point scaling**: scale `quantity` and `share_price` by `1e10` on the **write** side (`DECIMAL_SCALE` in `contracts.ts`, `scaleAmount` in `useDirectIssueStock.ts`). The poller unscales by `1e10`, so skipping this produces tiny fractions in Mongo.
+- **UUID ↔ bytes16**: use `uuidToBytes16`, `bytes16ToUuid`, and `generateBytes16Id` from `src/utils/uuid.ts` for any id sent to / read from a contract.
+- **Two write paths**:
+  - *Direct wallet* (current default for `/manage`): `useDirect*` hooks submit the tx from the connected wallet, then the matching `registerXxxOnchain` service POSTs metadata to `/<entity>/register-onchain`. The poller stays authoritative.
+  - *Server-signed* (legacy): `create*` services POST to `/<entity>/create` and the server's OPERATOR key submits onchain.
+- **API access**: the frontend calls `/api/*`; `next.config.js` rewrites that to `NEXT_PUBLIC_API_URL` (default `http://localhost:8293`).
 
 ### Theming
 
-The theme is defined in `src/components/theme.tsx` and typed in `styled.d.ts`. Available properties:
+The theme is defined in `src/components/theme.tsx` and typed in `styled.d.ts`. Token groups:
+
 - `colors`: background, main, input, text, accent, outline, success, successBg, error, errorBg, pending, pendingBg
 - `fontSizes`: H1, H2, H3, large, medium, baseline, small
 - `lineHeights`: H1, H2, H3, P
-- `borderRadius`: none, main
+- `fontWeights`: normal (400), medium (500), semibold (600), bold (700)
+- `spacing`: 0, xs, sm, md, lg, xl, 2xl, 3xl
+- `borderRadius`: none, main — plus `radii`: none, main, sm, md
+- `breakpoints`: sm (475px), mobile (512px), tablet (768px), mintCollapse (900px)
+- `shadows`: sm, focus
+- `transitions`: default, spring
+- `maxWidths`: main, article, h1
+- `zIndices`: base, dropdown, modal
 
-**Note:** `fontWeight` only has 'thin', 'normal', and 'bold' - no 'light' property.
+**Note:** `fontWeights` are `normal`, `medium`, `semibold`, `bold` — there is no `thin` or `light`.
 
 ## Styled-Components Style Guide
 
 ### File Organization
 - **Pure styled-component files** use **lowercase** filenames grouped by concern: `buttons.tsx`, `forms.tsx`, `typography.tsx`, `wrappers.tsx`.
-- **Component files with React logic/hooks** use **PascalCase**: `Navbar.tsx`, `Layout.tsx`.
+- **Component files with React logic/hooks** use **PascalCase**: `Navbar.tsx`, `CapTableDashboard.tsx`, `IssueStockForm.tsx`.
 - One file per concern — don't mix buttons and form inputs in the same file.
-- Inline styled components inside PascalCase component files are acceptable when the component is only used there (e.g., `NavActions` inside `Navbar.tsx`).
+- Inline styled components inside PascalCase component files are acceptable when only used there (e.g. `NavActions` inside `Navbar.tsx`).
 
 ### Naming & Exports
 - Use `const Name = styled.element` syntax.
@@ -65,45 +101,51 @@ The theme is defined in `src/components/theme.tsx` and typed in `styled.d.ts`. A
 - Avoid `default export` for files that only export styled components.
 
 ### Theme Tokens
-- Always use theme tokens via `${({ theme }) => theme.colors.main}` — never hard-code values that exist in the theme (colors, font sizes, line heights, border radii).
+- Always use theme tokens via `${({ theme }) => theme.colors.main}` — never hard-code values that exist in the theme (colors, sizes, line heights, radii, spacing, shadows, breakpoints, transitions, z-indices).
 - **Status colors**: use `theme.colors.success`, `error`, `pending` for borders and `successBg`, `errorBg`, `pendingBg` for backgrounds.
-- If you need a new color, add it to `theme.tsx` and `styled.d.ts` first — don't inline hex values.
-- `fontWeight` only supports `thin`, `normal`, and `bold` — no `light`.
+- If you need a new token, add it to `theme.tsx` and `styled.d.ts` first — don't inline raw values.
+- `fontWeights` only supports `normal`, `medium`, `semibold`, `bold`.
 
 ### CSS Conventions
 - **Indentation**: tabs (consistent with project Prettier config).
-- **Transitions**: `cubic-bezier(0.211, 0.69, 0.313, 1)` for standard UI interactions, `cubic-bezier(0.68, -0.55, 0.27, 1.55)` for spring/bounce effects.
-- **Transient props**: use `$` prefix (e.g., `$variant`) per styled-components v6 convention to avoid passing props to the DOM.
-- **Media breakpoints**: `768px` (tablet), `512px` (mobile), `475px` (small mobile).
+- **Transitions**: prefer `theme.transitions.default` (standard UI) and `theme.transitions.spring` (bounce) over inline cubic-beziers. The underlying curves are `cubic-bezier(0.211, 0.69, 0.313, 1)` and `cubic-bezier(0.68, -0.55, 0.27, 1.55)`.
+- **Breakpoints**: prefer `theme.breakpoints.*` (`sm` 475px, `mobile` 512px, `tablet` 768px, `mintCollapse` 900px) over raw pixel values.
+- **Transient props**: use `$` prefix (e.g. `$variant`) per styled-components v6 convention to avoid passing props to the DOM.
 - **`flex-flow` shorthand**: prefer `flex-flow: row nowrap` over separate `flex-direction` + `flex-wrap`.
 
-### Where New Components Go
-- Buttons → `buttons.tsx`
-- Form inputs, labels, field layouts → `forms.tsx`
-- Typography (headings, paragraphs) → `typography.tsx`
-- Layout containers, wrappers, panels → `wrappers.tsx`
-- Global styles → `globalstyle.tsx`
-- Theme definition → `theme.tsx`
-- Sample/seed data → `src/samples/`
-- Runtime configuration → `src/config/`
+### Where New Code Goes
+- Buttons → `buttons.tsx`; form inputs/labels/field layouts → `forms.tsx`; typography → `typography.tsx`; layout containers/wrappers/panels → `wrappers.tsx`; global styles → `globalstyle.tsx`; theme → `theme.tsx`.
+- React components with logic → PascalCase files in `src/components/`.
+- Wallet/onchain hooks → `src/hooks/`.
+- API client wrappers → `src/services/`.
+- Web3 + runtime config → `src/config/`.
+- Sample/seed data → `src/samples/`.
 
 ## Coding Conventions
 
 ### TypeScript / TSX
 - Tab indentation, double quotes for strings.
 - Named exports for styled-component files; `default export` for page/component files with logic.
-- Use `type` keyword for type-only exports (`export type { ... }`).
-- Keep page components in `src/pages/`, reusable UI in `src/components/`, config in `src/config/`, sample data in `src/samples/`.
-- Avoid creating `features/` directories for styled components or config — those belong in `components/` and `config/` respectively.
+- Use the `type` keyword for type-only exports (`export type { ... }`).
+- Keep pages in `src/pages/`, reusable UI in `src/components/`, hooks in `src/hooks/`, API wrappers in `src/services/`, config in `src/config/`, sample data in `src/samples/`.
+- Avoid creating `features/` directories — use the folders above.
+- Never hand-edit `src/generated.ts`; regenerate with `pnpm generate:wagmi`.
 
 ### Solidity
-- SPDX license header on every file.
-- NatSpec comments with `@inheritdoc` for interface implementations.
-- `snake_case` for struct fields (OCF convention), `camelCase` for function names.
-- Custom errors (e.g., `error InvalidWallet(address)`) over `require` strings where possible.
-- Events for all state-changing operations.
-- See root `WARP.md` for full Solidity and project conventions.
+The frontend contains no Solidity. For contract conventions (NatSpec, custom errors, events, roles, snake_case OCF fields) and the smart-contract toolchain, see the root [`WARP.md`](../WARP.md).
+
+## Environment Variables
+
+Frontend config lives in `app/.env.local` (git-ignored — never commit secrets). All are build-time public (`NEXT_PUBLIC_*`):
+
+- `NEXT_PUBLIC_REOWN_PROJECT_ID` — Reown/WalletConnect project id (https://cloud.reown.com)
+- `NEXT_PUBLIC_FACTORY_ADDRESS` — deployed `CapTableFactory` address
+- `NEXT_PUBLIC_CHAIN_ID` — chain the frontend targets (e.g. 98866 Plume Mainnet)
+- `NEXT_PUBLIC_API_URL` — API server URL the `/api/*` rewrite proxies to (default `http://localhost:8293`)
+- `NEXT_PUBLIC_OPERATOR_ADDRESS` — server wallet to receive OPERATOR_ROLE on new cap tables
+
+See the root `.env.example` for the canonical list.
 
 ## Git Workflow
 
-PR titles should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g., `feat(ui): add new component`).
+PR titles should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat(ui): add new component`). Branch from `main`; see the root [`CONTRIBUTING.md`](../CONTRIBUTING.md).


### PR DESCRIPTION
what?
•  rewrote app/WARP.md to reflect the wallet-based cap-table dapp (/mint, /manage, /manage/cap-table): the wagmi/viem/reown stack, generated contract hooks (src/generated.ts), the config/hooks/services/utils/samples structure, onchain conventions (1e10 write-side scaling, uuid↔bytes16, direct-wallet vs register-onchain), and the current theme tokens.
•  updated the root WARP.md frontend section and both README.md files to match.
•  added root AGENTS.md and CLAUDE.md pointer files for non-warp agents.
•  refreshed the .grok/skills/review checklist and fixed the ocf validation helper name (validateInputAgainstOCF → validateInputAgainstSchema).

why?
•  the frontend grew from a static landing page into a wallet-based cap-table app, but the agent-facing docs were stale — they pointed agents at the wrong structure, missing commands (generate:wagmi), and outdated theme tokens (e.g. font weights).

how?
•  docs-only changes, split into four atomic commits by concern (warp docs, readmes, agent pointer files, grok skill). no source or contract changes.

testing
•  pnpm --filter tap-app typecheck passes; no source files were touched.