### PR TITLE
fix(cap-table): unblock first issuance + poller/factory ops tooling

### DIFF
--- a/WARP.md
+++ b/WARP.md
@@ -119,6 +119,10 @@ When a manifest is created, the system:
 
 ### Setup
 
+**Fast path (Plume):** `pnpm bootstrap` does the whole setup idempotently — builds contracts if needed, creates the external `offchain-db` volume, `docker compose up -d --build`, and waits for API health. It does **not** hardcode a factory: if none is registered it points you to `pnpm deploy-factory` (which deploys and auto-registers your own). Safe to re-run whenever you come back to the project. For the wallet mint/manage UI, also run `pnpm app:dev` (it reads `app/.env.local`).
+
+Manual steps:
+
 ```bash
 # Install dependencies
 pnpm install
@@ -512,6 +516,9 @@ Libraries:
 7. **Preprocessor cache not populated**: Ensure seeding happens after manifest creation.
 8. **Mixing `/create` and `/register-onchain` semantics**: `/create` makes the server submit onchain; `/register-onchain` assumes the caller already did. Don't reintroduce a `suppliedId`-style overload on the `/create` route — that pattern was explicitly removed.
 9. **Optimistic-state dedupe by stakeholder+stockclass**: Don't. Multiple issuances can exist for the same pair; deduping there hides legitimate in-flight rows. Use a TTL (current: 90s) and let the aggregated holding row absorb the new total once the poller catches up.
+10. **MongoDB "Connection ended" log lines are not an error**: they're normal idle connection-pool churn (`connectionCount` ticks down as pooled sockets close). A real failure logs "Error connecting to Mongo". The poller printing `Processing for <issuer>: <block>` with an advancing block number means it is healthy.
+11. **Factory config has two independent sources — don't conflate them**: the server reads the factory from the Mongo `factories` collection (`deployCapTable` uses `factories[0].factory_address`); the frontend reads `NEXT_PUBLIC_FACTORY_ADDRESS` from `app/.env.local`. The root `.env` `NEXT_PUBLIC_*` only feed `docker-compose` interpolation into the **server**, not the Docker `app`. The factory address is deployment-specific (deployer wallet + nonce) and the implementation is an **upgradeable** beacon target, so **never hardcode them**: `pnpm deploy-factory` auto-registers both from the real deploy, and `pnpm factory:register --factory <addr>` reads the current implementation from the factory onchain (`upsertFactory` keeps a single record — one operator factory, many cap tables). Keep the Mongo factory and `app/.env.local` on the same address. A factory's **owner** (the wallet that deployed it) controls beacon upgrades for all its cap tables; for `0xcd6Df14406b0569ceEABa884A18717774EdeaCA1` that owner is the `.env` server wallet `0x366aA8…` and its current impl is `0xB63C08…` (the docs page's `0xef269…` is the stale pre-upgrade impl). Only reuse a factory whose owner wallet you control.
+12. **Issuing a stakeholder's first stock**: the Issue Stock dropdown needs the issuer's stakeholders, so `GET /cap-table/holdings/stock` returns `stakeholders` (and `stockClasses`) — the manage UI can populate the dropdown before any issuance exists. Don't source the stakeholder list only from `holdings[]`; it's empty until stock is issued, which would make a fresh cap table unable to issue its first shares after a page reload.
 
 ## Debugging
 
@@ -519,6 +526,8 @@ Libraries:
 - **Database**: Connect to MongoDB on port 27017 (credentials in `.env`)
 - **Blockchain**: Use RPC_URL to query contract state with ethers.js or cast
 - **Event poller**: Runs in-process by default; check console for event processing logs
+- **Poller block number stalled or far behind head**: fast-forward the per-issuer index with `pnpm poller:fast-forward` (`--issuer <id>`, `--block <n>`, `--dry-run`, `--help`). It sets `last_processed_block` to (near) chain head so the poller stops chasing a backlog and just tracks new blocks — handy on fast chains (Plume) or after the server was offline. Skips events between the old pointer and head, which is fine for a cap table with no real positions yet.
+- **"Connection ended" Mongo logs**: benign idle connection-pool churn, not a connectivity problem (see Common Pitfalls).
 
 ## Additional Resources
 

--- a/app/src/components/CapTableDashboard.tsx
+++ b/app/src/components/CapTableDashboard.tsx
@@ -126,15 +126,25 @@ export function CapTableDashboard({ issuerResult, onReset }: CapTableDashboardPr
 	}, [currentView, issuerResult?._id]);
 
 	// Build options for the Issue form + drawer from holdings + optimistic + direct onchain creates
+	// De-dupe by _id so an entity that is both returned by the server and present in this
+	// session's optimistic list (e.g. after a refresh) doesn't appear twice in the dropdown.
+	const dedupeById = (items: any[]) => {
+		const byId = new Map(items.filter(Boolean).map((x: any) => [x._id, x]));
+		return Array.from(byId.values());
+	};
+
 	const stockClassOptions = useMemo(() => {
 		const fromHoldings = manager.holdings?.stockClasses || [];
-		return [...fromHoldings, ...manager.createdStockClasses, ...directStockClasses].filter(Boolean);
+		return dedupeById([...fromHoldings, ...manager.createdStockClasses, ...directStockClasses]);
 	}, [manager.holdings?.stockClasses, manager.createdStockClasses, directStockClasses]);
 
 	const stakeholderOptions = useMemo(() => {
+		// Full stakeholder list from the server (works even before any stock is issued)...
+		const fromServer = manager.holdings?.stakeholders || [];
+		// ...plus any surfaced via existing holdings, plus this session's optimistic creates.
 		const fromHoldings = (manager.holdings?.holdings || []).map((h: { stakeholder?: any }) => h.stakeholder).filter(Boolean);
-		return [...fromHoldings, ...manager.createdStakeholders, ...directStakeholders].filter(Boolean);
-	}, [manager.holdings?.holdings, manager.createdStakeholders, directStakeholders]);
+		return dedupeById([...fromServer, ...fromHoldings, ...manager.createdStakeholders, ...directStakeholders]);
+	}, [manager.holdings?.stakeholders, manager.holdings?.holdings, manager.createdStakeholders, directStakeholders]);
 
 	const handleStockClass = async (data: StockClassData) => {
 		if (!capTableAddress || !directStockClass.isConnected) {
@@ -392,6 +402,11 @@ export function CapTableDashboard({ issuerResult, onReset }: CapTableDashboardPr
 						stakeholders={stakeholderOptions}
 						onSubmit={handleIssuance}
 						disabled={manager.isLoadingHoldings || stockClassOptions.length === 0 || stakeholderOptions.length === 0}
+						hint={
+							!manager.isLoadingHoldings && (stockClassOptions.length === 0 || stakeholderOptions.length === 0)
+								? "Add a stakeholder and a stock class first, then click Refresh to load them here."
+								: undefined
+						}
 					/>
 				</Panel>
 

--- a/app/src/components/IssueStockForm.tsx
+++ b/app/src/components/IssueStockForm.tsx
@@ -14,6 +14,7 @@ interface Props {
 	stakeholders: Option[];
 	onSubmit: (data: StockIssuanceData) => Promise<void>;
 	disabled?: boolean;
+	hint?: string;
 }
 
 const defaultData: Omit<StockIssuanceData, "stakeholder_id" | "stock_class_id"> = {
@@ -25,7 +26,7 @@ const defaultData: Omit<StockIssuanceData, "stakeholder_id" | "stock_class_id"> 
 	comments: ["Founder stock issuance"],
 };
 
-export function IssueStockForm({ stockClasses, stakeholders, onSubmit, disabled }: Props) {
+export function IssueStockForm({ stockClasses, stakeholders, onSubmit, disabled, hint }: Props) {
 	const [stakeholderId, setStakeholderId] = useState("");
 	const [stockClassId, setStockClassId] = useState("");
 	const [data, setData] = useState(defaultData);
@@ -56,6 +57,7 @@ export function IssueStockForm({ stockClasses, stakeholders, onSubmit, disabled 
 	return (
 		<div>
 			<SectionLabel>Issue Stock</SectionLabel>
+			{disabled && hint ? <p style={{ opacity: 0.6, fontSize: "0.85rem", margin: "0 0 0.5rem" }}>{hint}</p> : null}
 
 			<FieldRow>
 				<FieldGroup>

--- a/app/src/hooks/useCapTableManager.ts
+++ b/app/src/hooks/useCapTableManager.ts
@@ -7,6 +7,7 @@ import { createStockIssuance, type CreateStockIssuancePayload, type StockIssuanc
 export interface HoldingsData {
 	issuer?: any;
 	stockClasses?: any[];
+	stakeholders?: any[];
 	holdings?: Array<{
 		stakeholder: any;
 		stockClass: any;
@@ -60,10 +61,11 @@ export function useCapTableManager(issuerResult: IssuerResponse | null): UseCapT
 
 	const fetchHoldings = useCallback(async () => {
 		if (!issuerId) return;
+		const url = `/api/cap-table/holdings/stock?issuerId=${encodeURIComponent(issuerId)}`;
 		setIsLoadingHoldings(true);
 		setHoldingsError(null);
 		try {
-			const res = await fetch(`/api/cap-table/holdings/stock?issuerId=${encodeURIComponent(issuerId)}`);
+			const res = await fetch(url);
 			if (!res.ok) {
 				const text = await res.text();
 				throw new Error(text || `Failed to load holdings (${res.status})`);
@@ -72,7 +74,8 @@ export function useCapTableManager(issuerResult: IssuerResponse | null): UseCapT
 			setHoldings(data);
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err);
-			setHoldingsError(msg);
+			console.error("[capTableManager] holdings fetch failed for", url, err);
+			setHoldingsError(`Couldn't load cap table data from ${url} — ${msg}`);
 		} finally {
 			setIsLoadingHoldings(false);
 		}

--- a/app/src/hooks/useDirectCreateStockClass.ts
+++ b/app/src/hooks/useDirectCreateStockClass.ts
@@ -38,8 +38,13 @@ export function useDirectCreateStockClass() {
       // Scale the price (protocol uses 1e10 fixed point for prices)
       const scaledPrice = scaleAmount(params.pricePerShareAmount);
 
-      // Shares authorized
-      const sharesAuthorized = BigInt(params.initialSharesAuthorized);
+      // Shares authorized must ALSO be scaled by 1e10: the issuer's authorized shares, the
+      // issuance quantity (useDirectIssueStock), and the poller all use 1e10 fixed point. If we
+      // store this unscaled, issueStock compares a scaled quantity against an unscaled authorized
+      // and reverts ("StockClass: Insufficient shares authorized"). Shares are whole numbers, so
+      // use BigInt math to avoid the float precision loss that scaleAmount() would hit at >2^53.
+      const SHARE_SCALE = 10_000_000_000n; // 1e10
+      const sharesAuthorized = BigInt(params.initialSharesAuthorized) * SHARE_SCALE;
 
       writeContract({
         address: params.capTableAddress,

--- a/app/src/pages/manage/cap-table.tsx
+++ b/app/src/pages/manage/cap-table.tsx
@@ -51,8 +51,8 @@ export default function ManageCapTablePage() {
 							};
 						}
 					}
-				} catch {
-					// fall through to lastMintedIssuer fallback below
+				} catch (err) {
+					console.warn("[manage] /api/issuer/full failed, falling back to localStorage:", err);
 				}
 
 				if (!loadedIssuer) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
         "docker:up": "docker compose up -d",
         "docker:down": "docker compose down",
         "docker:logs": "docker compose logs -f",
-        "docker:build": "docker compose up -d --build"
+        "docker:build": "docker compose up -d --build",
+        "bootstrap": "./scripts/bootstrap-plume.sh",
+        "poller:fast-forward": "tsx server/scripts/fastForwardPoller.ts",
+        "factory:register": "tsx server/scripts/registerFactory.ts"
     },
     "dependencies": {
         "ajv": "^8.12.0",

--- a/scripts/bootstrap-plume.sh
+++ b/scripts/bootstrap-plume.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+set -e
+
+# Usage: ./scripts/bootstrap-plume.sh   (or: pnpm bootstrap)
+#
+# Idempotent, one-command setup for the full TAP stack against Plume Mainnet.
+# Safe to re-run — every step checks current state before acting:
+#   1. Ensure a root .env exists (copied from .env.example if missing)
+#   2. Build contracts if chain/out is missing (the server image COPYs them)
+#   3. Ensure the external `offchain-db` Docker volume exists (compose marks it external)
+#   4. Bring up the Docker stack (mongodb, server, app)
+#   5. Wait for the API health endpoint
+#   6. Check the Mongo `factories` collection. We never hardcode/seed a factory: a transfer-agent
+#      operator deploys their OWN factory (pnpm deploy-factory, which auto-registers it). If none
+#      is registered, this prints guidance. Set REUSE_TAP_FACTORY=1 to register an existing Plume
+#      factory (implementation read onchain); only reuse a factory whose owner wallet you control.
+#
+# Overrides: API_URL, REUSE_TAP_FACTORY=1.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+
+# Reuse-only: an existing CapTableFactory on Plume. Used ONLY when REUSE_TAP_FACTORY=1.
+# By default this script does NOT register any factory — deploy your own with `pnpm deploy-factory`
+# (which auto-registers it). The implementation is read from the factory onchain, never hardcoded.
+# NOTE: the factory's owner (the wallet that deployed it) controls beacon upgrades for all its cap
+# tables — only reuse a factory whose owner wallet you control.
+TAP_FACTORY_ADDRESS="0xcd6Df14406b0569ceEABa884A18717774EdeaCA1"
+API_URL="${API_URL:-http://localhost:8293}"
+
+echo "🚀 TAP bootstrap (Plume)"
+echo "========================"
+
+# 1. Root .env
+if [ ! -f .env ]; then
+    cp .env.example .env
+    echo "📝 Created .env from .env.example — set RPC_URL/CHAIN_ID/PRIVATE_KEY for Plume before deploying."
+else
+    echo "✅ .env present"
+fi
+
+# 2. Contracts (the server image COPYs chain/out at build time)
+if [ ! -d chain/out ]; then
+    echo "⚒️  chain/out missing — building contracts (pnpm setup)..."
+    pnpm setup
+else
+    echo "✅ chain/out present"
+fi
+
+# 3. External volume footgun (compose declares offchain-db as external)
+if ! docker volume inspect offchain-db >/dev/null 2>&1; then
+    echo "📦 Creating external Docker volume offchain-db..."
+    docker volume create offchain-db >/dev/null
+else
+    echo "✅ offchain-db volume present"
+fi
+
+# 4. Bring up the stack
+echo "🐳 Starting Docker stack (mongodb, server, app)..."
+docker compose up -d --build
+
+# 5. Wait for API health
+printf "⏳ Waiting for API at %s " "$API_URL"
+for i in $(seq 1 60); do
+    if curl -fsS "$API_URL/" >/dev/null 2>&1; then
+        echo "— up"
+        break
+    fi
+    printf "."
+    sleep 2
+    if [ "$i" -eq 60 ]; then
+        echo " timed out"
+        echo "❌ API did not become healthy. Check: pnpm docker:logs"
+        exit 1
+    fi
+done
+
+# 6. Factory registration — never hardcode. Deploy your own, or explicitly opt into reuse.
+MONGO_CID="$(docker compose ps -q mongodb)"
+if [ -z "$MONGO_CID" ]; then
+    echo "❌ mongodb container not found"
+    exit 1
+fi
+FACTORY_COUNT="$(docker exec "$MONGO_CID" mongosh "mongodb://tap:tap@localhost:27017/mongo?authSource=admin" --quiet --eval 'print(db.factories.countDocuments())' | tr -dc '0-9')"
+if [ "${FACTORY_COUNT:-0}" -gt 0 ]; then
+    echo "✅ Factory already registered in Mongo (count=$FACTORY_COUNT) — leaving as-is."
+elif [ "${REUSE_TAP_FACTORY:-0}" = "1" ]; then
+    echo "🌱 REUSE_TAP_FACTORY=1 — registering existing Plume factory $TAP_FACTORY_ADDRESS (impl read onchain)..."
+    echo "   (Beacon-upgrade control stays with that factory's owner wallet — only reuse one you control.)"
+    pnpm factory:register --factory "$TAP_FACTORY_ADDRESS"
+else
+    echo "ℹ️  No factory registered yet. As a transfer-agent operator, deploy your OWN factory:"
+    echo "      pnpm deploy-factory          # deploys CapTable + CapTableFactory and registers them in Mongo"
+    echo "   Or register an existing factory you control:"
+    echo "      pnpm factory:register --factory 0x... --implementation 0x..."
+    echo "   (Dev convenience — reuse TAP's shared Plume factory: REUSE_TAP_FACTORY=1 pnpm bootstrap)"
+fi
+
+echo ""
+echo "========================"
+echo "🎉 Bootstrap complete."
+echo "  Server API:   $API_URL"
+echo "  App (Docker): http://localhost:3000  (landing page)"
+echo "  Wallet mint/manage UI: run 'pnpm app:dev' (reads app/.env.local), then open http://localhost:3000/mint"
+echo ""
+echo "Once a factory is registered (see above), deploy the first cap table with the server wallet:"
+echo "  curl -X POST $API_URL/issuer/create -H 'Content-Type: application/json' -d @your-issuer.json"
+echo ""
+echo "If the poller's block number stalls or lags far behind head, fast-forward the index:"
+echo "  pnpm poller:fast-forward            # all issuers -> chain head"
+echo "  pnpm poller:fast-forward --help     # options"
+echo ""

--- a/scripts/deployFactory.sh
+++ b/scripts/deployFactory.sh
@@ -15,15 +15,19 @@ set -e
 #   4. CapTable implementation contract
 #   5. CapTableFactory (constructor takes CapTable address)
 #
-# After deployment, add the factory to MongoDB to use the API.
+# After a successful deploy, the factory + implementation are auto-registered in MongoDB
+# (addresses written from the deploy output, never hardcoded). Use --no-register to skip.
 
 # Parse arguments
 USE_ENV_FILE=".env"
 VERIFY=false
+NO_REGISTER=false
 
 for arg in "$@"; do
     if [ "$arg" = "--verify" ]; then
         VERIFY=true
+    elif [ "$arg" = "--no-register" ]; then
+        NO_REGISTER=true
     elif [ -f "$arg" ]; then
         USE_ENV_FILE="$arg"
     fi
@@ -62,6 +66,7 @@ fi
 export ETH_RPC_URL="$RPC_URL"
 COMMON_FLAGS="--private-key $PRIVATE_KEY --broadcast --legacy $VERIFY_FLAGS"
 
+ROOT_DIR="$(pwd)"
 cd chain
 
 echo ""
@@ -152,8 +157,21 @@ echo "CapTable (implementation): $CAP_TABLE_ADDR"
 echo "CapTableFactory:           $FACTORY_ADDR"
 echo "========================================"
 echo ""
-echo "Add to MongoDB factories collection:"
-echo "{"
-echo "  \"implementation_address\": \"$CAP_TABLE_ADDR\","
-echo "  \"factory_address\": \"$FACTORY_ADDR\""
-echo "}"
+# Register the deployed addresses in Mongo so the server/API deploys cap tables through
+# THIS factory. These addresses are unique to this deployment — written from the deploy
+# output, never hardcoded. Skip with --no-register and register manually as shown.
+if [ "$NO_REGISTER" = true ]; then
+    echo "Skipping DB registration (--no-register). Register it manually with:"
+    echo "  pnpm factory:register --factory $FACTORY_ADDR --implementation $CAP_TABLE_ADDR"
+else
+    echo "🌱 Registering factory in Mongo (pnpm factory:register)..."
+    cd "$ROOT_DIR"
+    if pnpm factory:register --factory "$FACTORY_ADDR" --implementation "$CAP_TABLE_ADDR"; then
+        echo "✅ Factory registered — the API will deploy cap tables through it."
+    else
+        echo "⚠️  Auto-registration failed (is Mongo up? try 'pnpm docker:up'). Register it with either:"
+        echo "  pnpm factory:register --factory $FACTORY_ADDR --implementation $CAP_TABLE_ADDR"
+        echo "  ...or insert into the Mongo 'factories' collection (e.g. via MongoDB Compass):"
+        echo "  { \"implementation_address\": \"$CAP_TABLE_ADDR\", \"factory_address\": \"$FACTORY_ADDR\" }"
+    fi
+fi

--- a/server/routes/capTable.ts
+++ b/server/routes/capTable.ts
@@ -89,7 +89,10 @@ capTable.get("/holdings/stock", async (req, res) => {
                 timestamp: Number(timestamp),
             });
         }
-        res.send({ holdings, stockClasses, issuer });
+        // Return the full stakeholder list too: the manage UI needs it to populate the
+        // Issue Stock dropdown for a freshly set-up cap table that has no issuances yet
+        // (holdings is empty until stock is issued, so it can't be the only source).
+        res.send({ holdings, stockClasses, stakeholders, issuer });
     } catch (error) {
         console.error(error);
         res.status(500).send(`${error}`);

--- a/server/scripts/fastForwardPoller.ts
+++ b/server/scripts/fastForwardPoller.ts
@@ -1,0 +1,114 @@
+/*
+ * Fast-forward the event poller index (`last_processed_block`) for one or all issuers.
+ *
+ * The poller (server/chain-operations/transactionPoller.ts) advances each issuer's
+ * `last_processed_block` toward chain head. When an issuer is far behind head (large
+ * backlog) or otherwise stuck, the off-chain DB stops reflecting new blocks and the
+ * block number appears frozen. This script jumps `last_processed_block` to (near) the
+ * current chain head so the poller stops chasing the backlog and only watches new
+ * blocks — unblocking feature work.
+ *
+ * Run from the repo root (talks to the Dockerized Mongo via the .env DATABASE_URL):
+ *   pnpm poller:fast-forward                  # all active issuers -> current chain head
+ *   pnpm poller:fast-forward --issuer <id>    # only this issuer
+ *   pnpm poller:fast-forward --block <n>      # explicit target block (skips RPC head lookup)
+ *   pnpm poller:fast-forward --buffer <n>     # target = head - n (default 0; re-scan last n blocks)
+ *   pnpm poller:fast-forward --dry-run        # print intended changes, write nothing
+ *
+ * Reuses the server's env/DB/provider helpers so it honors .env (DATABASE_URL, RPC_URL).
+ */
+import mongoose from "mongoose";
+import getProvider from "../chain-operations/getProvider.js";
+import { connectDB } from "../db/config/mongoose.ts";
+import { readAllIssuers, readIssuerById } from "../db/operations/read.js";
+import { updateIssuerById } from "../db/operations/update.js";
+import { isFlagPresent } from "../utils/commandLine.ts";
+import { setupEnv } from "../utils/env.js";
+
+setupEnv();
+
+const getArgValue = (flag: string): string | undefined => {
+    const idx = process.argv.indexOf(flag);
+    if (idx === -1) return undefined;
+    return process.argv[idx + 1];
+};
+
+const parseNonNegativeInt = (raw: string | undefined, flag: string): number | undefined => {
+    if (raw === undefined) return undefined;
+    const value = Number.parseInt(raw, 10);
+    if (Number.isNaN(value) || value < 0) {
+        throw new Error(`Invalid ${flag}: "${raw}" (expected a non-negative integer)`);
+    }
+    return value;
+};
+
+const main = async () => {
+    if (isFlagPresent("--help") || isFlagPresent("-h")) {
+        console.log(
+            [
+                "Fast-forward the poller index (last_processed_block).",
+                "",
+                "  --issuer <id>   only this issuer (default: all issuers with deployed_to)",
+                "  --block <n>     explicit target block (default: current chain head)",
+                "  --buffer <n>    target = head - n (default 0; ignored with --block)",
+                "  --dry-run       print intended changes without writing",
+            ].join("\n")
+        );
+        return;
+    }
+
+    const issuerId = getArgValue("--issuer");
+    const explicitBlock = parseNonNegativeInt(getArgValue("--block"), "--block");
+    const buffer = parseNonNegativeInt(getArgValue("--buffer"), "--buffer") ?? 0;
+    const dryRun = isFlagPresent("--dry-run");
+
+    await connectDB();
+
+    // Resolve the target block: explicit --block wins, otherwise current chain head - buffer.
+    let targetBlock: number;
+    if (explicitBlock !== undefined) {
+        targetBlock = explicitBlock;
+        console.log(`🎯 | Target block (explicit): ${targetBlock}`);
+    } else {
+        const head = await getProvider().getBlockNumber();
+        targetBlock = Math.max(head - buffer, 0);
+        console.log(`🔗 | Chain head ${head}, buffer ${buffer} -> target block ${targetBlock}`);
+    }
+
+    // Resolve the target issuers.
+    let issuers: any[];
+    if (issuerId) {
+        const issuer = await readIssuerById(issuerId);
+        if (!issuer) {
+            throw new Error(`Issuer ${issuerId} not found`);
+        }
+        issuers = [issuer];
+    } else {
+        issuers = (await readAllIssuers()).filter((i: any) => i.deployed_to);
+    }
+
+    if (issuers.length === 0) {
+        console.log("⚠️ | No active issuers (with deployed_to) to fast-forward.");
+        return;
+    }
+
+    console.log(`${dryRun ? "🔎 [dry-run] " : ""}Fast-forwarding ${issuers.length} issuer(s) to block ${targetBlock}`);
+    for (const issuer of issuers) {
+        const before = issuer.last_processed_block;
+        if (dryRun) {
+            console.log(`🔎 | [dry-run] ${issuer._id}: last_processed_block ${before} -> ${targetBlock}`);
+            continue;
+        }
+        await updateIssuerById(issuer._id, { last_processed_block: targetBlock });
+        console.log(`✅ | ${issuer._id}: last_processed_block ${before} -> ${targetBlock}`);
+    }
+};
+
+main()
+    .catch((err) => {
+        console.error("❌ | Fast-forward failed:", err);
+        process.exitCode = 1;
+    })
+    .finally(async () => {
+        await mongoose.disconnect();
+    });

--- a/server/scripts/registerFactory.ts
+++ b/server/scripts/registerFactory.ts
@@ -1,0 +1,115 @@
+/*
+ * Register (or update) the CapTableFactory + implementation addresses in Mongo.
+ *
+ * The server deploys cap tables through the factory recorded in the Mongo `factories`
+ * collection (`deployCapTable` uses `factories[0].factory_address`). These addresses are
+ * deployment-specific — they're derived from the operator's deployer wallet + nonce — so
+ * they must come from a real `pnpm deploy-factory` run, never a hardcoded constant. A
+ * transfer-agent operator deploys ONE factory and manages MANY cap tables under it; the
+ * factory owner controls the beacon upgrade for all of them, so operators should own (and
+ * register) their own factory rather than reuse someone else's.
+ *
+ * Usage (from repo root, talks to the Dockerized Mongo via the .env DATABASE_URL):
+ *   pnpm factory:register --factory 0x... --implementation 0x...
+ *   pnpm factory:register --factory 0x... --dry-run
+ *
+ * `upsertFactory` keeps a single factory record (one factory, many cap tables), so
+ * re-running updates it in place.
+ */
+import { ethers } from "ethers";
+import mongoose from "mongoose";
+import getProvider from "../chain-operations/getProvider.js";
+import { connectDB } from "../db/config/mongoose.ts";
+import { readfactories } from "../db/operations/read.js";
+import { upsertFactory } from "../db/operations/update.js";
+import { isFlagPresent } from "../utils/commandLine.ts";
+import { setupEnv } from "../utils/env.js";
+
+setupEnv();
+
+const getArgValue = (flag: string): string | undefined => {
+    const idx = process.argv.indexOf(flag);
+    if (idx === -1) return undefined;
+    return process.argv[idx + 1];
+};
+
+const isAddress = (v: string | undefined): v is string => !!v && /^0x[0-9a-fA-F]{40}$/.test(v);
+
+const main = async () => {
+    if (isFlagPresent("--help") || isFlagPresent("-h")) {
+        console.log(
+            [
+                "Register the CapTableFactory + implementation in Mongo (single-record upsert).",
+                "",
+                "  --factory <addr>         CapTableFactory address (required)",
+                "  --implementation <addr>  CapTable implementation (optional; read from the factory onchain if omitted)",
+                "  --dry-run                print the intended change, write nothing",
+            ].join("\n")
+        );
+        return;
+    }
+
+    const factoryAddress = getArgValue("--factory");
+    let implementationAddress = getArgValue("--implementation");
+    const dryRun = isFlagPresent("--dry-run");
+
+    if (!isAddress(factoryAddress)) {
+        throw new Error(`--factory must be a 0x-prefixed 20-byte address (got: ${factoryAddress ?? "<missing>"})`);
+    }
+    if (implementationAddress !== undefined && !isAddress(implementationAddress)) {
+        throw new Error(`--implementation must be a 0x-prefixed 20-byte address (got: ${implementationAddress})`);
+    }
+
+    // The implementation is an upgradeable beacon target, not a fixed constant. If it wasn't
+    // passed explicitly, read the factory's CURRENT implementation onchain so the DB reflects
+    // the live beacon — never hardcode it (a hardcoded impl goes stale after a beacon upgrade).
+    if (!implementationAddress) {
+        try {
+            const factory = new ethers.Contract(
+                factoryAddress,
+                ["function capTableImplementation() view returns (address)"],
+                getProvider()
+            );
+            const derived: string = await factory.capTableImplementation();
+            if (isAddress(derived) && derived !== ethers.ZeroAddress) {
+                implementationAddress = derived;
+                console.log(`🔗 | Read implementation from factory onchain: ${implementationAddress}`);
+            }
+        } catch (err) {
+            console.warn(
+                "⚠️ | Could not read implementation from factory (continuing; implementation_address is informational):",
+                err instanceof Error ? err.message : err
+            );
+        }
+    }
+
+    await connectDB();
+
+    const before = await readfactories();
+    console.log(
+        "before:",
+        before.map((f: any) => ({ factory_address: f.factory_address, implementation_address: f.implementation_address }))
+    );
+
+    const payload: { factory_address: string; implementation_address?: string } = { factory_address: factoryAddress };
+    if (implementationAddress) payload.implementation_address = implementationAddress;
+
+    if (dryRun) {
+        console.log(`🔎 | [dry-run] would upsert ${JSON.stringify(payload)}`);
+        return;
+    }
+
+    const factory = await upsertFactory(payload);
+    console.log(
+        `✅ | Registered factory_address=${factory.factory_address} implementation_address=${factory.implementation_address ?? "(unset)"}`
+    );
+};
+
+main()
+    .catch((err) => {
+        console.error("❌ | Factory registration failed:", err);
+        process.exitCode = 1;
+    })
+    .finally(async () => {
+        await mongoose.disconnect();
+    });


### PR DESCRIPTION
## What?
- **server**: `GET /cap-table/holdings/stock` now returns the issuer's `stakeholders` (alongside `holdings`/`stockClasses`/`issuer`).
- **app**: Issue Stock dropdowns source from the server lists (deduped by `_id`); holdings/issuer fetch errors are surfaced (no more silent "No holdings yet"); disabled-state hint added.
- **app**: stock-class `shares_authorized` is scaled by 1e10 in `useDirectCreateStockClass`.
- **ops**: `pnpm poller:fast-forward`, `pnpm factory:register`, `deployFactory.sh` auto-registration, idempotent `pnpm bootstrap`.
- **docs**: `WARP.md` factory model + poller/bootstrap tooling.

## Why?
- A freshly minted cap table could never issue a stakeholder's **first** stock: the dropdown had no source for stakeholders until an issuance already existed (circular dependency).
- The stock-class authorized shares were stored unscaled, so **every** `issueStock` reverted with `StockClass: Insufficient shares authorized`.
- The event poller can lag far behind a fast chain (Plume), and the factory/first-touch setup was brittle (manual MongoDB Compass insert, hardcoded deployment-specific addresses).

## How?
- Return the already-loaded stakeholder list from the holdings route; the dashboard merges + dedupes server + optimistic lists.
- Scale shares with BigInt math to match the 1e10 fixed-point convention used by the issuer authorized + issuance quantity.
- New `tsx` tools reuse existing DB ops (`upsertFactory`, `updateIssuerById`) and read the implementation from the factory **onchain** (never hardcoded); `deployFactory.sh` calls `factory:register`; `bootstrap-plume.sh` is idempotent and guides deploying your own factory.

