### PR TITLE
docs: improve readability with content patterns and guide cleanup

### DIFF
--- a/docs/src/components/ContentPatterns.jsx
+++ b/docs/src/components/ContentPatterns.jsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+
+export function NextActions({ children, items = [] }) {
+	return (
+		<section className="tap-next-actions" aria-label="Next actions">
+			{children ? <p className="tap-next-actions__intro">{children}</p> : null}
+			<div className="tap-next-actions__grid">
+				{items.map(({ href, title, description, meta }) => (
+					<Link className="tap-next-action" href={href} key={`${href}-${title}`}>
+						<span className="tap-next-action__title">{title}</span>
+						{description ? <span className="tap-next-action__description">{description}</span> : null}
+						{meta ? <code className="tap-next-action__meta">{meta}</code> : null}
+					</Link>
+				))}
+			</div>
+		</section>
+	);
+}
+
+export function Detail({ summary, children, open = false }) {
+	return (
+		<details className="tap-detail" open={open}>
+			<summary>{summary}</summary>
+			<div className="tap-detail__body">{children}</div>
+		</details>
+	);
+}
+
+export function Route({ method, children }) {
+	return (
+		<span className="tap-route">
+			<span className={`tap-method tap-method--${method.toLowerCase()}`}>{method}</span>
+			<code>{children}</code>
+		</span>
+	);
+}

--- a/docs/src/pages/api-reference.mdx
+++ b/docs/src/pages/api-reference.mdx
@@ -4,6 +4,8 @@ import { Callout } from 'nextra/components';
 
 Base URL: `http://localhost:8293`.
 
+Use the page outline to jump directly to a route family. Start with **Behavior** if you are deciding whether a route writes onchain, writes only to MongoDB, or appears in poller-backed history.
+
 <Callout type="info">
 This reference covers the server-signed API and automation surface. The product UI under `/app` is wallet-first: the connected issuer ADMIN writes directly onchain, then registers class, stakeholder, and issuance metadata with the corresponding `register-onchain` route. Transfers are mirrored by the poller and have no registration route.
 </Callout>

--- a/docs/src/pages/development/cap-table-deploy.mdx
+++ b/docs/src/pages/development/cap-table-deploy.mdx
@@ -1,4 +1,5 @@
 import { Steps, Callout } from 'nextra/components';
+import { NextActions } from '../../components/ContentPatterns';
 
 # Create an Issuer
 
@@ -120,30 +121,15 @@ It will look like this, with your unique `_id`
 }
 ```
 
-![Issuer Response](../../../public/images/cap-table-issuer.png)
-
 <Callout type="warning">
 The `deployed_to` address is unique to your deployment—it's derived from your wallet and transaction nonce.
 </Callout>
 
 </Steps>
 
-## Wallet flow details
-
-Issuers deploy cap tables directly from the frontend at `/app/mint`:
-
-1. Connect a wallet via the navigation bar
-2. Fill in the issuer details (legal name, formation date, shares authorized, etc.)
-3. Click **Mint Cap Table** — the connected wallet calls `createCapTable` on the factory
-4. The issuer's wallet becomes **ADMIN** and the configured operator address, when present, receives **OPERATOR** role
-5. After onchain confirmation, the frontend automatically registers the issuer in the server database via `POST /issuer/register`
-
-In this flow, the issuer pays gas and administers that cap table. A configured operator can also perform day-to-day writes, but it does not own the factory or issuer ADMIN role.
-
-The frontend sends the same bytes16 issuer ID to the factory and to `POST /issuer/register`. Do not change it between the wallet transaction and server registration, or the poller cannot match the issuer event to the database record.
-
 ## What's next?
 
-With your issuer created, continue with:
-1. [Create a Stock Class](/development/create-stock-class) — define equity classes before issuing stock
-2. [Create a Stakeholder](/development/create-stakeholder) — add equity holders to your cap table
+<NextActions items={[
+  { title: 'Create a stock class', href: '/development/create-stock-class', description: 'Define the equity class before issuing positions.' },
+  { title: 'Create a stakeholder', href: '/development/create-stakeholder', description: 'Add the person or institution that will hold equity.' }
+]} />

--- a/docs/src/pages/development/create-stakeholder.mdx
+++ b/docs/src/pages/development/create-stakeholder.mdx
@@ -1,4 +1,5 @@
 import { Steps } from 'nextra/components';
+import { Detail, NextActions } from '../../components/ContentPatterns';
 
 # Create a Stakeholder
 
@@ -21,13 +22,15 @@ The smallest valid body identifies the issuer and the stakeholder's name, type, 
 }
 ```
 
-Use the full body below when you also want to capture contact details.
+Use the full request when you also want to capture contact details.
 
 <Steps>
 
 ### Send a POST request
 
 Using Postman or curl, send a POST request to `http://localhost:8293/stakeholder/create`
+
+<Detail summary="Show full request with contact details">
 
 ```json
 {
@@ -79,11 +82,15 @@ Using Postman or curl, send a POST request to `http://localhost:8293/stakeholder
 }
 ```
 
+</Detail>
+
 Replace `<YOUR_ISSUER_ID>` with the `_id` from your issuer creation response.
 
 ### Check the response
 
-The response includes your new stakeholder:
+The response includes your new stakeholder. Keep `_id`; later issuances and transfers use it.
+
+<Detail summary="Show complete response">
 
 ```json
 {
@@ -138,7 +145,7 @@ The response includes your new stakeholder:
 }
 ```
 
-![Stakeholder Response](../../../public/images/stakeholder-issuer.png)
+</Detail>
 
 The `is_onchain_synced` field starts as `false`. The event poller will update it to `true` once the blockchain confirms the transaction.
 
@@ -172,4 +179,7 @@ The `current_relationship` field accepts values like:
 
 ## What's next?
 
-With stakeholders and stock classes created, you can now [issue stock](/development/issue-stock) to your stakeholders.
+<NextActions items={[
+  { title: 'Issue stock', href: '/development/issue-stock', description: 'Create the stakeholder’s first active position.' },
+  { title: 'Create another stakeholder', href: '/development/create-stakeholder', description: 'Add another holder before allocating shares.' }
+]} />

--- a/docs/src/pages/development/create-stock-class.mdx
+++ b/docs/src/pages/development/create-stock-class.mdx
@@ -1,4 +1,5 @@
 import { Steps } from 'nextra/components';
+import { NextActions } from '../../components/ContentPatterns';
 
 # Create a Stock Class
 
@@ -58,8 +59,6 @@ The response includes your new stock class:
     }
 }
 ```
-![Stock Class Response](../../../public/images/stock-class-issuer.png)
-
 On the server-signed `/create` path, `is_onchain_synced` starts as `false` and the event poller updates it after processing the confirmed event. The wallet-first `/register-onchain` path records the already-confirmed write as synced immediately.
 
 </Steps>
@@ -84,4 +83,7 @@ The `class_type` field accepts these values per the OCF standard:
 
 ## What's next?
 
-With a stock class created, you can now [create stakeholders](/development/create-stakeholder) who will hold equity in your company.
+<NextActions items={[
+  { title: 'Create a stakeholder', href: '/development/create-stakeholder', description: 'Add a person or institution that can receive equity.' },
+  { title: 'Issue stock', href: '/development/issue-stock', description: 'Already have a stakeholder? Create their first position.' }
+]} />

--- a/docs/src/pages/development/historical-transactions.mdx
+++ b/docs/src/pages/development/historical-transactions.mdx
@@ -1,4 +1,5 @@
 import { Steps, Callout } from 'nextra/components';
+import { NextActions } from '../../components/ContentPatterns';
 
 # Historical Transactions
 
@@ -25,8 +26,6 @@ The response is an array of historical transactions, each containing:
 - `transaction`: the full transaction object (populated from the referenced document)
 - `transactionType`: the type of transaction (e.g., `StockIssuance`, `StockTransfer`)
 - `issuer`: the issuer ID this transaction belongs to
-
-![Historical Transactions](../../../public/images/fetch-historical-transactions.png)
 
 </Steps>
 
@@ -74,5 +73,8 @@ The response is a flat array in MongoDB insertion order. No pagination is built 
 
 ## What's next?
 
-- Use `security_id` from a `StockIssuance` row to [transfer stock](/development/transfer-stock) or [change an existing security](/features/corporate-actions/transfer-cancel-and-reissue-stock).
-- See [View Cap Table](/features/cap-table-management/view-cap-table) to read current holdings rather than full history.
+<NextActions items={[
+  { title: 'Transfer stock', href: '/development/transfer-stock', description: 'Use the active canonical security ID from history.' },
+  { title: 'View current cap table', href: '/features/cap-table-management/view-cap-table', description: 'Read current holdings instead of the complete event trail.' },
+  { title: 'Change a security', href: '/features/corporate-actions/transfer-cancel-and-reissue-stock', description: 'Cancel, retract, reissue, repurchase, or accept a position.' }
+]} />

--- a/docs/src/pages/development/install.mdx
+++ b/docs/src/pages/development/install.mdx
@@ -15,6 +15,15 @@ curl -L https://foundry.paradigm.xyz | bash
 - [pnpm](https://pnpm.io/installation) — the package manager used throughout this project
 - [MongoDB Compass](https://www.mongodb.com/try/download/compass) — optional GUI for inspecting the database during development
 
+Verify the required tools before cloning:
+
+```bash
+docker --version
+forge --version
+node --version
+pnpm --version
+```
+
 ## Pull the repo
 
 ```bash

--- a/docs/src/pages/development/issue-stock.mdx
+++ b/docs/src/pages/development/issue-stock.mdx
@@ -1,4 +1,5 @@
 import { Steps, Callout } from 'nextra/components';
+import { NextActions } from '../../components/ContentPatterns';
 
 # Issue Stock
 
@@ -67,8 +68,6 @@ API examples use human `share_price.amount` values. The contract stores them sca
 }
 ```
 
-![Stock Issuance Response](../../../public/images/issue-stock.png)
-
 </Steps>
 
 ## Outputs
@@ -103,9 +102,8 @@ This returns all stock issuances, transfers, cancellations, and other equity eve
 
 ## What's next?
 
-With stock issued, you can:
-- Transfer stock between stakeholders via `POST /transactions/transfer/stock`
-- Cancel stock via `POST /transactions/cancel/stock`
-- View transaction history via `GET /historical-transactions/issuer-id/:issuerId`
-
-See the [Cap Table API](/features) guides for the grouped API reference, especially [Transfer, Cancel, and Reissue Stock](/features/corporate-actions/transfer-cancel-and-reissue-stock).
+<NextActions items={[
+  { title: 'View history', href: '/development/historical-transactions', description: 'Wait for the poller and copy the canonical security ID.', meta: 'GET /historical-transactions/issuer-id/:issuerId' },
+  { title: 'Transfer stock', href: '/development/transfer-stock', description: 'Move some or all of the active position to another stakeholder.' },
+  { title: 'Other security actions', href: '/features/corporate-actions/transfer-cancel-and-reissue-stock', description: 'Cancel, retract, reissue, repurchase, or accept stock.' }
+]} />

--- a/docs/src/pages/development/run-server.mdx
+++ b/docs/src/pages/development/run-server.mdx
@@ -4,6 +4,13 @@ import { Steps, Callout } from 'nextra/components';
 
 Healthy local product stack: **Docker for Mongo + API + poller**, **host Next for the wallet UI**.
 
+| Start order | Process | Why it runs |
+| --- | --- | --- |
+| 1 | MongoDB | Persists the local OCF mirror. |
+| 2 | API + poller | Serves reads/automation and mirrors confirmed events. |
+| 3 | Product UI | Connects the issuer ADMIN wallet for direct writes. |
+| 4 | Docs, optional | Serves this reference locally. |
+
 ## Docker (Mongo + API)
 
 <Steps>

--- a/docs/src/pages/development/transfer-stock.mdx
+++ b/docs/src/pages/development/transfer-stock.mdx
@@ -1,4 +1,5 @@
 import { Steps, Callout } from 'nextra/components';
+import { NextActions } from '../../components/ContentPatterns';
 
 # Transfer Stock
 
@@ -8,65 +9,9 @@ Transfer shares from one stakeholder to another. The recipient (transferee) must
 
 <Steps>
 
-### Create the transferee stakeholder
+### Confirm the transferee exists
 
-Before transferring, ensure the recipient exists. Send a POST request to `http://localhost:8293/stakeholder/create`
-
-```json
-{
-    "issuerId": "<YOUR_ISSUER_ID>",
-    "data": {
-        "name": {
-            "legal_name": "Zach McKinnon",
-            "first_name": "Zach",
-            "last_name": "McKinnon"
-        },
-        "issuer_assigned_id": "",
-        "stakeholder_type": "INDIVIDUAL",
-        "current_relationship": "INVESTOR",
-        "primary_contact": {
-            "name": {
-                "legal_name": "Zach McKinnon",
-                "first_name": "Zach",
-                "last_name": "McKinnon"
-            },
-            "emails": [
-                {
-                    "email_type": "BUSINESS",
-                    "email_address": "zachary@plume.org"
-                }
-            ],
-            "phone_numbers": [
-                {
-                    "phone_type": "MOBILE",
-                    "phone_number": "+1 555-555-555"
-                }
-            ]
-        },
-        "contact_info": {
-            "emails": [
-                {
-                    "email_type": "BUSINESS",
-                    "email_address": "zachary@plume.org"
-                }
-            ],
-            "phone_numbers": [
-                {
-                    "phone_type": "MOBILE",
-                    "phone_number": "+1 555-555-555"
-                }
-            ]
-        },
-        "comments": []
-    }
-}
-```
-
-![Create Transferee Stakeholder](../../../public/images/stakeholder-transferee.png)
-
-<Callout type="info">
-See [Create a Stakeholder](/development/create-stakeholder) for more details on stakeholder fields.
-</Callout>
+The recipient must already be a stakeholder on this issuer. If needed, complete [Create a Stakeholder](/development/create-stakeholder), then return with the recipient's stakeholder ID.
 
 ### Transfer the stock
 
@@ -92,8 +37,6 @@ The response returns `"success"` when the transfer is recorded onchain.
 `sharePrice` is the human price per share. The contract stores it scaled by 1e10 (10,000,000,000). Divide raw onchain values by 1e10 before comparing. The server handles scaling automatically.
 </Callout>
 
-![Stock Transfer Response](../../../public/images/transfer-stock.png)
-
 ### Verify the transfer
 
 Check historical transactions to confirm:
@@ -101,8 +44,6 @@ Check historical transactions to confirm:
 ```
 GET /historical-transactions/issuer-id/<YOUR_ISSUER_ID>
 ```
-
-![Historical Transactions](../../../public/images/transfer-stock-history.png)
 
 </Steps>
 
@@ -123,9 +64,8 @@ If `quantity` is less than the current position on `security_id`, the contract a
 
 ## What's next?
 
-After transferring stock, you can:
-- View all transactions via `GET /historical-transactions/issuer-id/:issuerId`
-- Cancel stock via `POST /transactions/cancel/stock`
-- Issue more stock via `POST /transactions/issuance/stock`
-
-See the [Cap Table API](/features) guides for the grouped API reference, especially [Transfer, Cancel, and Reissue Stock](/features/corporate-actions/transfer-cancel-and-reissue-stock).
+<NextActions items={[
+  { title: 'View history', href: '/development/historical-transactions', description: 'Confirm the transfer and find any new balance security ID.', meta: 'GET /historical-transactions/issuer-id/:issuerId' },
+  { title: 'Change a security', href: '/features/corporate-actions/transfer-cancel-and-reissue-stock', description: 'Cancel, retract, reissue, repurchase, or accept an active position.', meta: 'POST /transactions/…' },
+  { title: 'Issue more stock', href: '/development/issue-stock', description: 'Create another position for an existing stakeholder.', meta: 'POST /transactions/issuance/stock' }
+]} />

--- a/docs/src/pages/features.mdx
+++ b/docs/src/pages/features.mdx
@@ -1,8 +1,10 @@
 import { Cards } from 'nextra/components';
 
-# Cap Table API
+# API and Record Guides
 
 Reference guides for the optional server-signed API and record types. For the primary wallet-first product workflow, start at the [Development Guide](/development). Exact server routes: [API Reference](/api-reference).
+
+Choose this section when you already understand the core issuer workflow and need to look up a record family or automation route.
 
 <Cards>
   <Cards.Card title="Manage Issuer" href="/features/issuer-management" />

--- a/docs/src/pages/features/cap-table-management.mdx
+++ b/docs/src/pages/features/cap-table-management.mdx
@@ -1,5 +1,3 @@
-import { Cards } from 'nextra/components';
-
 # Manage Cap Table
 
 Use this section after first-time setup, when you need supporting records, an optional acceptance event, or a read of current holdings.
@@ -13,9 +11,3 @@ For first-time setup, use [Create Stock Class](/development/create-stock-class),
 | Save legends, plans, or update stakeholder wallets | [Add Supporting Records](/features/cap-table-management/create-stock-class-and-shareholders) | Supporting records saved or wallet linked to a stakeholder. |
 | Record acceptance after an issuance | [Issue and Accept Stock](/features/cap-table-management/issue-and-accept-stock) | Standalone `stockAcceptance` event for an existing `security_id`. |
 | See who currently holds stock for an issuer | [View Cap Table](/features/cap-table-management/view-cap-table) | Active stock positions, stock classes, and the issuer record. |
-
-<Cards>
-  <Cards.Card title="Add Supporting Records" href="/features/cap-table-management/create-stock-class-and-shareholders" />
-  <Cards.Card title="Issue and Accept Stock" href="/features/cap-table-management/issue-and-accept-stock" />
-  <Cards.Card title="View Cap Table" href="/features/cap-table-management/view-cap-table" />
-</Cards>

--- a/docs/src/pages/features/cap-table-management/create-stock-class-and-shareholders.mdx
+++ b/docs/src/pages/features/cap-table-management/create-stock-class-and-shareholders.mdx
@@ -1,4 +1,5 @@
 import { Callout } from 'nextra/components';
+import { Detail } from '../../../components/ContentPatterns';
 
 # Add Supporting Records
 
@@ -22,6 +23,8 @@ Use [Create Stock Class](/development/create-stock-class) and [Create Stakeholde
 
 `POST /stock-legend/create` saves transfer-restriction text that you can attach to issuances later via `stock_legend_ids`.
 
+<Detail summary="Show stock-legend request">
+
 ```json
 {
     "issuerId": "<YOUR_ISSUER_ID>",
@@ -32,6 +35,8 @@ Use [Create Stock Class](/development/create-stock-class) and [Create Stakeholde
     }
 }
 ```
+
+</Detail>
 
 | Field | Required | Description |
 | --- | --- | --- |
@@ -44,6 +49,8 @@ Returns: `{ "stockLegend": ... }`.
 ## Stock plans
 
 `POST /stock-plan/create` saves plan terms that future equity-compensation issuances reference via `stock_plan_id`.
+
+<Detail summary="Show stock-plan request">
 
 ```json
 {
@@ -60,11 +67,15 @@ Returns: `{ "stockLegend": ... }`.
 }
 ```
 
+</Detail>
+
 Returns: `{ "stockPlan": ... }`.
 
 ## Wallets
 
 `POST /stakeholder/add-wallet` and `POST /stakeholder/remove-wallet`:
+
+<Detail summary="Show wallet request">
 
 ```json
 {
@@ -73,6 +84,8 @@ Returns: `{ "stockPlan": ... }`.
     "wallet": "<YOUR_WALLET_ADDRESS>"
 }
 ```
+
+</Detail>
 
 Returns: `"Success"`. Add can also return `"Wallet already added"`.
 

--- a/docs/src/pages/features/cap-table-management/view-cap-table.mdx
+++ b/docs/src/pages/features/cap-table-management/view-cap-table.mdx
@@ -1,4 +1,5 @@
 import { Steps, Callout } from 'nextra/components';
+import { NextActions } from '../../../components/ContentPatterns';
 
 # View Cap Table
 
@@ -65,4 +66,7 @@ curl "http://localhost:8293/cap-table/holdings/stock?issuerId=<YOUR_ISSUER_ID>"
 
 ## What's next?
 
-Use this page for the current state. Use [View History](/features/issuer-management/read-history) when you want to see how the cap table got there.
+<NextActions items={[
+  { title: 'View history', href: '/features/issuer-management/read-history', description: 'See the transactions that produced the current state.' },
+  { title: 'Add new history', href: '/features/issuer-management/append-history', description: 'Choose an onchain action that the poller will append.' }
+]} />

--- a/docs/src/pages/features/corporate-actions.mdx
+++ b/docs/src/pages/features/corporate-actions.mdx
@@ -1,5 +1,3 @@
-import { Cards } from 'nextra/components';
-
 # Corporate Actions
 
 Use this section after the first stock issuance, when you need to change holdings or save supporting data for later transactions.
@@ -11,12 +9,6 @@ Use this section after the first stock issuance, when you need to change holding
 | Transfer, cancel, retract, reissue, or repurchase shares; adjust authorized shares | [Transfer, Cancel, and Reissue Stock](/features/corporate-actions/transfer-cancel-and-reissue-stock) | Yes, after polling. |
 | Save options, RSUs, SARs, SAFEs, or notes | [Save Equity Compensation and Convertibles](/features/corporate-actions/save-offchain-corporate-actions) | No — record only. |
 | Save 409A valuations, vesting terms, legends, or stock plans | [Save Valuations and Terms](/features/corporate-actions/update-valuations-and-terms) | No — record only. |
-
-<Cards>
-  <Cards.Card title="Transfer, Cancel, and Reissue Stock" href="/features/corporate-actions/transfer-cancel-and-reissue-stock" />
-  <Cards.Card title="Save Equity Compensation and Convertibles" href="/features/corporate-actions/save-offchain-corporate-actions" />
-  <Cards.Card title="Save Valuations and Terms" href="/features/corporate-actions/update-valuations-and-terms" />
-</Cards>
 
 ## Not available through TAP today
 

--- a/docs/src/pages/features/corporate-actions/save-offchain-corporate-actions.mdx
+++ b/docs/src/pages/features/corporate-actions/save-offchain-corporate-actions.mdx
@@ -1,4 +1,5 @@
 import { Callout } from 'nextra/components';
+import { Detail } from '../../../components/ContentPatterns';
 
 # Save Equity Compensation and Convertibles
 
@@ -21,6 +22,8 @@ These `/transactions` routes require `issuerId`, but they only save MongoDB reco
 ## Equity compensation
 
 `POST /transactions/issuance/equity-compensation`
+
+<Detail summary="Show equity-compensation request">
 
 ```json
 {
@@ -50,6 +53,8 @@ These `/transactions` routes require `issuerId`, but they only save MongoDB reco
 }
 ```
 
+</Detail>
+
 Returns: `{ "equityCompensationIssuance": ... }`.
 
 ### `compensation_type` values
@@ -64,6 +69,8 @@ Returns: `{ "equityCompensationIssuance": ... }`.
 ## Convertible
 
 `POST /transactions/issuance/convertible`
+
+<Detail summary="Show convertible request">
 
 ```json
 {
@@ -101,6 +108,8 @@ Returns: `{ "equityCompensationIssuance": ... }`.
     }
 }
 ```
+
+</Detail>
 
 Returns: `{ "convertibleIssuance": ... }`.
 

--- a/docs/src/pages/features/corporate-actions/transfer-cancel-and-reissue-stock.mdx
+++ b/docs/src/pages/features/corporate-actions/transfer-cancel-and-reissue-stock.mdx
@@ -1,4 +1,5 @@
 import { Callout } from 'nextra/components';
+import { Detail } from '../../../components/ContentPatterns';
 
 # Transfer, Cancel, and Reissue Stock
 
@@ -21,6 +22,8 @@ All routes here are `/transactions` routes and require `issuerId` in the body. E
 
 `POST /transactions/transfer/stock`
 
+<Detail summary="Show transfer request">
+
 ```json
 {
     "issuerId": "<YOUR_ISSUER_ID>",
@@ -34,6 +37,8 @@ All routes here are `/transactions` routes and require `issuerId` in the body. E
     }
 }
 ```
+
+</Detail>
 
 Returns: `"success"`.
 
@@ -63,6 +68,8 @@ Use these to raise or lower how many shares the issuer (or a single stock class)
 
 `POST /transactions/adjust/issuer/authorized-shares`
 
+<Detail summary="Show issuer authorized-shares request">
+
 ```json
 {
     "issuerId": "<YOUR_ISSUER_ID>",
@@ -75,11 +82,15 @@ Use these to raise or lower how many shares the issuer (or a single stock class)
 }
 ```
 
+</Detail>
+
 Returns: `{ "issuerAuthorizedSharesAdj": ... }`.
 
 ### Stock-class-level
 
 `POST /transactions/adjust/stock-class/authorized-shares`
+
+<Detail summary="Show stock-class authorized-shares request">
 
 ```json
 {
@@ -93,6 +104,8 @@ Returns: `{ "issuerAuthorizedSharesAdj": ... }`.
     }
 }
 ```
+
+</Detail>
 
 Returns: `{ "stockClassAdjustment": ... }`. The class authorized cap can never exceed the issuer authorized cap.
 

--- a/docs/src/pages/features/corporate-actions/update-valuations-and-terms.mdx
+++ b/docs/src/pages/features/corporate-actions/update-valuations-and-terms.mdx
@@ -1,4 +1,5 @@
 import { Callout } from 'nextra/components';
+import { Detail } from '../../../components/ContentPatterns';
 
 # Save Valuations and Terms
 
@@ -20,6 +21,8 @@ Records are immutable in TAP. When terms change, create a new record and referen
 
 `POST /valuation/create`
 
+<Detail summary="Show valuation request">
+
 ```json
 {
     "issuerId": "<YOUR_ISSUER_ID>",
@@ -39,6 +42,8 @@ Records are immutable in TAP. When terms change, create a new record and referen
 }
 ```
 
+</Detail>
+
 Returns: `{ "valuation": ... }`.
 
 ### `valuation_type` values
@@ -52,6 +57,8 @@ Returns: `{ "valuation": ... }`.
 ## Vesting terms
 
 `POST /vesting-terms/create`
+
+<Detail summary="Show vesting-terms request">
 
 ```json
 {
@@ -75,6 +82,8 @@ Returns: `{ "valuation": ... }`.
 }
 ```
 
+</Detail>
+
 Returns: `{ "vestingTerms": ... }`.
 
 ### `vesting_conditions[]` fields
@@ -96,6 +105,8 @@ Returns: `{ "vestingTerms": ... }`.
 
 Stock plan body:
 
+<Detail summary="Show stock-plan request">
+
 ```json
 {
     "issuerId": "<YOUR_ISSUER_ID>",
@@ -110,6 +121,8 @@ Stock plan body:
     }
 }
 ```
+
+</Detail>
 
 ## Stock class
 

--- a/docs/src/pages/features/issuer-management.mdx
+++ b/docs/src/pages/features/issuer-management.mdx
@@ -1,5 +1,3 @@
-import { Cards } from 'nextra/components';
-
 # Manage Issuer
 
 Use this section when the issuer already exists and you only need to register, audit, or extend its history. For first-time issuer creation, use [Create an Issuer](/development/cap-table-deploy).
@@ -11,9 +9,3 @@ Use this section when the issuer already exists and you only need to register, a
 | Add a TAP record for a cap table that was deployed elsewhere, or import an OCF manifest | [Register or Import Issuer](/features/issuer-management/create-issuer) | TAP issuer record linked to your existing onchain cap table. |
 | Check whether a stock action or share adjustment was recorded | [View History](/features/issuer-management/read-history) | List of historical transactions for the issuer. |
 | See which routes create a new history entry vs. save data only | [Add New History](/features/issuer-management/append-history) | Reference of routes by behavior. |
-
-<Cards>
-  <Cards.Card title="Register or Import Issuer" href="/features/issuer-management/create-issuer" />
-  <Cards.Card title="View History" href="/features/issuer-management/read-history" />
-  <Cards.Card title="Add New History" href="/features/issuer-management/append-history" />
-</Cards>

--- a/docs/src/pages/features/issuer-management/append-history.mdx
+++ b/docs/src/pages/features/issuer-management/append-history.mdx
@@ -1,4 +1,5 @@
 import { Callout } from 'nextra/components';
+import { NextActions } from '../../../components/ContentPatterns';
 
 # Add New History
 
@@ -16,30 +17,30 @@ History entries are produced by the event poller after a contract transaction is
 
 These routes submit an onchain transaction. After the poller processes the event (~20 s on Plume Mainnet), the entry appears in [View History](/features/issuer-management/read-history).
 
-- Stock actions:
-  - `POST /transactions/issuance/stock`
-  - `POST /transactions/transfer/stock`
-  - `POST /transactions/cancel/stock`
-  - `POST /transactions/retract/stock`
-  - `POST /transactions/reissue/stock`
-  - `POST /transactions/repurchase/stock`
-  - `POST /transactions/accept/stock`
-- Authorized share adjustments:
-  - `POST /transactions/adjust/issuer/authorized-shares`
-  - `POST /transactions/adjust/stock-class/authorized-shares`
+| Route | Resulting history |
+| --- | --- |
+| `POST /transactions/issuance/stock` | New stock position |
+| `POST /transactions/transfer/stock` | Transfer and any balance position |
+| `POST /transactions/cancel/stock` | Cancellation |
+| `POST /transactions/retract/stock` | Retraction |
+| `POST /transactions/reissue/stock` | Reissuance |
+| `POST /transactions/repurchase/stock` | Repurchase |
+| `POST /transactions/accept/stock` | Acceptance |
+| `POST /transactions/adjust/issuer/authorized-shares` | Issuer authorized-share adjustment |
+| `POST /transactions/adjust/stock-class/authorized-shares` | Stock-class authorized-share adjustment |
 
 ## Routes that only save data
 
 These routes write a MongoDB record only. They never appear in history on their own.
 
-- Equity compensation and convertibles:
-  - `POST /transactions/issuance/equity-compensation`
-  - `POST /transactions/issuance/convertible`
-- Supporting records:
-  - `POST /stock-legend/create`
-  - `POST /stock-plan/create`
-  - `POST /valuation/create`
-  - `POST /vesting-terms/create`
+| Route | Storage |
+| --- | --- |
+| `POST /transactions/issuance/equity-compensation` | MongoDB equity-compensation record |
+| `POST /transactions/issuance/convertible` | MongoDB convertible record |
+| `POST /stock-legend/create` | MongoDB supporting record |
+| `POST /stock-plan/create` | MongoDB supporting record |
+| `POST /valuation/create` | MongoDB supporting record |
+| `POST /vesting-terms/create` | MongoDB supporting record |
 
 ## Verify a new history entry
 
@@ -49,4 +50,7 @@ These routes write a MongoDB record only. They never appear in history on their 
 
 ## What's next?
 
-Use [Transfer, Cancel, and Reissue Stock](/features/corporate-actions/transfer-cancel-and-reissue-stock) for routes that add new history. Use [Save Equity Compensation and Convertibles](/features/corporate-actions/save-offchain-corporate-actions) for routes that save data without adding history.
+<NextActions items={[
+  { title: 'Onchain security actions', href: '/features/corporate-actions/transfer-cancel-and-reissue-stock', description: 'Use routes that create poller-backed history.' },
+  { title: 'Offchain instruments', href: '/features/corporate-actions/save-offchain-corporate-actions', description: 'Save compensation and convertibles without chain history.' }
+]} />

--- a/docs/src/pages/features/issuer-management/create-issuer.mdx
+++ b/docs/src/pages/features/issuer-management/create-issuer.mdx
@@ -1,4 +1,5 @@
 import { Callout } from 'nextra/components';
+import { NextActions } from '../../../components/ContentPatterns';
 
 # Register or Import Issuer
 
@@ -85,4 +86,7 @@ For most workflows, the response from `POST /issuer/create` or `POST /issuer/reg
 
 ## What's next?
 
-Use [View History](/features/issuer-management/read-history) to confirm what was recorded for the issuer.
+<NextActions items={[
+  { title: 'View history', href: '/features/issuer-management/read-history', description: 'Confirm seeded or poller-backed transactions.' },
+  { title: 'Create support records', href: '/features/cap-table-management/create-stock-class-and-shareholders', description: 'Add legends, plans, and wallets needed by later transactions.' }
+]} />

--- a/docs/src/pages/features/issuer-management/read-history.mdx
+++ b/docs/src/pages/features/issuer-management/read-history.mdx
@@ -1,4 +1,5 @@
 import { Steps, Callout } from 'nextra/components';
+import { NextActions } from '../../../components/ContentPatterns';
 
 # View History
 
@@ -56,4 +57,7 @@ Some routes save data but never appear here on their own — typically equity co
 
 ## What's next?
 
-Read [Add New History](/features/issuer-management/append-history) to see which routes add new history entries.
+<NextActions items={[
+  { title: 'Add new history', href: '/features/issuer-management/append-history', description: 'See which writes emit events and appear here.' },
+  { title: 'View current holdings', href: '/features/cap-table-management/view-cap-table', description: 'Read the latest cap-table state instead of the event trail.' }
+]} />

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -1,4 +1,5 @@
 import { Cards } from 'nextra/components';
+import { NextActions } from '../components/ContentPatterns';
 
 # Transfer Agent Protocol
 
@@ -26,3 +27,11 @@ The protocol has three major components.
 	<Cards.Card title="Open Cap Table Format" href="/protocol/tap-ocf"/>
 	<Cards.Card title="Onchain Cap Table" href="/protocol/tap-cap-table" />
 </Cards>
+
+## Start by role
+
+<NextActions items={[
+  { title: 'Issuer administrator', href: '/development', description: 'Run the stack and manage a cap table from a connected wallet.' },
+  { title: 'API integrator', href: '/api-reference', description: 'Automate server-signed workflows and read TAP records.' },
+  { title: 'Protocol engineer', href: '/protocol', description: 'Understand contracts, OCF records, libraries, and polling.' }
+]} />

--- a/docs/src/pages/protocol/solidity-reference.mdx
+++ b/docs/src/pages/protocol/solidity-reference.mdx
@@ -4,6 +4,8 @@ import { Callout } from 'nextra/components';
 
 First-party Solidity only: `chain/src`. Vendor code under `chain/lib` is out of scope.
 
+This is a lookup page, not a linear tutorial. Use the page outline to jump between writes, reads, factory methods, interfaces, and libraries. Start with [TAP Cap Table](/protocol/tap-cap-table) for the architecture and role model.
+
 ## CapTable writes
 
 `CapTable.sol` stores issuer, stock class, stakeholder, wallet, active position, and transaction state.

--- a/docs/src/pages/protocol/stock-lib.mdx
+++ b/docs/src/pages/protocol/stock-lib.mdx
@@ -2,6 +2,8 @@ import { Callout } from 'nextra/components';
 
 # Stock Functions
 
+Every lifecycle write follows the same shape: validate an active security, mutate active positions, encode the transaction, and emit an event for the poller. Partial operations may also create a new balance security.
+
 `StockLib` is `chain/src/lib/Stock.sol`. `CapTable` calls it for stock lifecycle writes.
 
 ## Library functions

--- a/docs/src/pages/protocol/structs-lib.mdx
+++ b/docs/src/pages/protocol/structs-lib.mdx
@@ -1,5 +1,7 @@
 # Structs Library
 
+Structs are grouped by where they enter the lifecycle: core records, active positions, initial seeding, function inputs, transaction payloads, and IDs. Use the page outline to jump directly to the group you need.
+
 `Structs.sol` is shared by `CapTable`, `StockLib`, `TxHelper`, and `Adjustment`.
 
 ## Core

--- a/docs/src/pages/protocol/tap-ocf.mdx
+++ b/docs/src/pages/protocol/tap-ocf.mdx
@@ -30,6 +30,13 @@ Note that "stakeholder" in OCF context is more specific than the general busines
 
 OCF defines the JSON shapes TAP uses for offchain records. The API routes on this site use those shapes for issuers, stakeholders, stock classes, transactions, and supporting records.
 
+| Concern | Onchain | OCF / MongoDB |
+| --- | --- | --- |
+| Authority | Canonical contract state and emitted events | Searchable mirror and metadata |
+| IDs | Compact `bytes16` values | UUID strings and Mongo document IDs |
+| Writes | Connected ADMIN wallet or server operator | Registration routes and event poller |
+| Recovery | Re-read contracts and event history | Reconcile or repopulate the mirror |
+
 Use the [Cap Table API](/features) guides for the routes you can call today. If you want the raw field-by-field reference, the generated schema docs live under `ocf/docs/schema_markdown`.
 
 ## Our Database

--- a/docs/src/pages/security.mdx
+++ b/docs/src/pages/security.mdx
@@ -6,6 +6,8 @@
 
 ## Current Status
 
+The workflow badge above is the live status. The counts below describe the checked-in reports and can change whenever analysis is rerun; verify them locally before relying on the snapshot.
+
 | Tool | High | Medium | Low | Status |
 |------|------|--------|-----|--------|
 | Aderyn | 0 | 0 | 5 | ✅ All acceptable |

--- a/docs/src/pages/tests.mdx
+++ b/docs/src/pages/tests.mdx
@@ -1,5 +1,16 @@
 # Testing Overview
 
+Start with **Before a PR** when choosing checks for a change. The matrices below document the broader Solidity coverage and invariants.
+
+## Before a PR
+
+| Change | Minimum check |
+| --- | --- |
+| Docs | `pnpm docs:build` |
+| Solidity logic | `make test` |
+| Share accounting or lifecycle | `make test && make test-invariant` |
+| Frontend | `pnpm app:build` |
+
 ## Commands
 
 | Goal | Command |
@@ -31,12 +42,3 @@
 | Class `shares_issued <= shares_authorized` | Prevent class over-issuance. |
 | Stakeholder and stock class counts stay consistent. | Catch index drift. |
 | Active position tracking stays consistent. | Catch stale securities and missing deletes. |
-
-## Before a PR
-
-| Change | Minimum check |
-| --- | --- |
-| Docs | `pnpm docs:build` |
-| Solidity logic | `make test` |
-| Share accounting or lifecycle | `make test && make test-invariant` |
-| Frontend | `pnpm app:build` |

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -107,6 +107,29 @@ article th {
 	word-break: normal;
 }
 
+article {
+	font-size: 15px;
+	line-height: 1.72;
+}
+
+article h1 {
+	letter-spacing: -0.035em;
+}
+
+article h2 {
+	margin-top: 2.4rem;
+}
+
+article h3 {
+	margin-top: 1.8rem;
+}
+
+article p,
+article ul,
+article ol {
+	max-width: 78ch;
+}
+
 article a {
 	color: var(--tap-signal) !important;
 	text-decoration: none;
@@ -261,9 +284,122 @@ article table[data-tap-columns^="Actor / deployment|Address|"] th:nth-child(1) {
 article table[data-tap-columns^="Actor / deployment|Address|"] th:nth-child(2) { width: 42%; }
 article table[data-tap-columns^="Actor / deployment|Address|"] th:nth-child(3) { width: 30%; }
 
+article table[data-tap-columns^="Field|Description|"] th:first-child,
+article table[data-tap-columns^="Field|Type|"] th:first-child,
+article table[data-tap-columns^="Function|Purpose|"] th:first-child,
+article table[data-tap-columns^="Route|Storage|"] th:first-child {
+	width: 30%;
+}
+
 .tap-table-frame--compact table,
 article table:has(th:nth-child(2):last-child) {
 	table-layout: auto;
+}
+
+.tap-next-actions {
+	margin-block: 1rem 2rem;
+}
+
+.tap-next-actions__intro {
+	color: var(--tap-muted);
+	margin-bottom: 0.75rem;
+}
+
+.tap-next-actions__grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+	gap: 0.75rem;
+}
+
+.tap-next-action {
+	display: flex;
+	min-width: 0;
+	flex-direction: column;
+	gap: 0.35rem;
+	padding: 0.9rem 1rem;
+	background: var(--tap-surface);
+	border: 1px solid var(--tap-border);
+	border-radius: 0.375rem;
+	color: var(--tap-text) !important;
+}
+
+.tap-next-action:hover {
+	border-color: rgba(200, 245, 66, 0.45);
+	text-decoration: none;
+}
+
+.tap-next-action__title {
+	color: var(--tap-signal);
+	font-weight: 700;
+}
+
+.tap-next-action__description {
+	color: var(--tap-muted);
+	font-size: 0.875rem;
+	line-height: 1.5;
+}
+
+.tap-next-action__meta {
+	align-self: flex-start;
+	margin-top: 0.2rem;
+	font-size: 0.72rem !important;
+}
+
+.tap-detail {
+	margin-block: 0.8rem;
+	background: var(--tap-surface);
+	border: 1px solid var(--tap-border);
+	border-radius: 0.375rem;
+}
+
+.tap-detail > summary {
+	cursor: pointer;
+	padding: 0.75rem 1rem;
+	color: var(--tap-text);
+	font-weight: 700;
+}
+
+.tap-detail > summary::marker {
+	color: var(--tap-signal);
+}
+
+.tap-detail[open] > summary {
+	border-bottom: 1px solid var(--tap-border);
+}
+
+.tap-detail__body {
+	min-width: 0;
+	padding: 0.2rem 1rem 1rem;
+}
+
+.tap-route {
+	display: inline-flex;
+	max-width: 100%;
+	align-items: baseline;
+	gap: 0.45rem;
+}
+
+.tap-method {
+	flex: 0 0 auto;
+	border: 1px solid var(--tap-border);
+	border-radius: 999px;
+	padding: 0.08rem 0.4rem;
+	font-size: 0.68rem;
+	font-weight: 700;
+	letter-spacing: 0.04em;
+}
+
+.tap-method--get { color: #7dd3fc; }
+.tap-method--post { color: var(--tap-signal); }
+.tap-method--put,
+.tap-method--patch { color: #fbbf24; }
+.tap-method--delete { color: #f87171; }
+
+/* Nextra cards should wrap descriptive labels rather than truncate the task. */
+article a[class*="nextra-card"] span,
+article a[class*="nextra-card"] {
+	white-space: normal !important;
+	overflow-wrap: break-word;
 }
 
 .mermaid,


### PR DESCRIPTION
## What?

Improves docs readability with shared content patterns and a cleaner guide structure.

**3 atomic commits:**
1. `feat(docs): add readable content patterns` — adds `ContentPatterns.jsx` and related globals CSS for consistent, scannable doc layout.
2. `docs: streamline development workflows` — tightens development setup/workflow pages for clearer path through local work.
3. `docs: reorganize reference and feature guides` — restructures API reference and feature guide pages for easier scanning.

## Why?

Docs were harder to scan after recent setup/Nextra work. Shared patterns and lighter copy make the development and feature guides easier to follow without changing product behavior.

## Testing

- Visual check via `pnpm docs:dev` (readability pass on affected pages)
- No runtime/API behavior changes (docs-only)