### PR TITLE
chore(docker): run app and server on Node 24

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,12 @@
-node_modules
+.git
+**/.DS_Store
+**/node_modules
+**/.next
+**/.turbo
+**/test-results
+**/*.tsbuildinfo
 npm-debug.log
+chain/lib
+chain/cache
+ocf/docs
+ocf/node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v6
               with:
-                  node-version: "lts/*"
+                  node-version: "24"
             - name: Install pnpm
               uses: pnpm/action-setup@v6
             - name: Get pnpm store directory

--- a/app/WARP.md
+++ b/app/WARP.md
@@ -189,7 +189,7 @@ Frontend config lives in `app/.env.local` (git-ignored). All are build-time publ
 
 See the root `.env.example` for the canonical list. Keep Mongo `factories` and this factory address aligned.
 
-**Host vs Docker:** Prefer `pnpm app:dev` for product work (`app/.env.local`). Docker app bind-mounts `app/` + `packages/` so source edits hot-reload; rebuild the image only after `package.json` / lockfile / Dockerfile changes. If `:3000` is Docker and you see `Can't resolve '@tap/units'`, `docker compose stop app` and use the host dev server. TAP Mongo is host **27027**.
+**Host vs Docker:** Prefer `pnpm app:dev` for product work (`app/.env.local`). The Docker app is a `next start` preview (no webpack/turbopack watcher — that polling ate ~8 cores). Rebuild the image after source or `NEXT_PUBLIC_*` changes. If `:3000` is Docker, `docker compose stop app` before host `pnpm app:dev`. TAP Mongo is host **27027**.
 
 ## Git Workflow
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,13 +58,15 @@ services:
             WATCHPACK_POLLING: "true"
             CHOKIDAR_USEPOLLING: "true"
             CHOKIDAR_INTERVAL: "1000"
-        command: ["pnpm", "dev", "--hostname", "0.0.0.0"]
+        command: ["pnpm", "dev", "--hostname", "0.0.0.0", "--webpack"]
         volumes:
             # Source mounts: edit app/ or packages/ on the host without rebuilding the image.
             # Rebuild (`pnpm docker:build`) is still required after package.json / lockfile / Dockerfile changes.
             - ./app:/app/app
             - ./packages:/app/packages
+            # Keep image node_modules and a container-local .next (host cache breaks Turbopack).
             - /app/app/node_modules
+            - /app/app/.next
         depends_on:
             mongodb:
                 condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,30 +43,21 @@ services:
         build:
             context: .
             dockerfile: docker/Dockerfile.app
+            args:
+                # Baked into the client bundle at image build.
+                NEXT_PUBLIC_API_URL: http://server:8293
+                NEXT_PUBLIC_FACTORY_ADDRESS: ${NEXT_PUBLIC_FACTORY_ADDRESS:-}
+                NEXT_PUBLIC_CHAIN_ID: ${NEXT_PUBLIC_CHAIN_ID:-${CHAIN_ID:-98866}}
+                NEXT_PUBLIC_OPERATOR_ADDRESS: ${NEXT_PUBLIC_OPERATOR_ADDRESS:-}
         restart: unless-stopped
         ports:
             - 3000:3000
         environment:
-            NODE_ENV: development
-            # Next server-side /api rewrites run inside this container → compose DNS.
-            # Host pnpm app:dev keeps app/.env.local on http://localhost:8293.
+            NODE_ENV: production
             NEXT_PUBLIC_API_URL: http://server:8293
             NEXT_PUBLIC_FACTORY_ADDRESS: ${NEXT_PUBLIC_FACTORY_ADDRESS:-}
             NEXT_PUBLIC_CHAIN_ID: ${NEXT_PUBLIC_CHAIN_ID:-${CHAIN_ID:-98866}}
             NEXT_PUBLIC_OPERATOR_ADDRESS: ${NEXT_PUBLIC_OPERATOR_ADDRESS:-}
-            # Docker Desktop bind mounts often miss inotify; poll so Next/Turbopack picks up edits.
-            WATCHPACK_POLLING: "true"
-            CHOKIDAR_USEPOLLING: "true"
-            CHOKIDAR_INTERVAL: "1000"
-        command: ["pnpm", "dev", "--hostname", "0.0.0.0", "--webpack"]
-        volumes:
-            # Source mounts: edit app/ or packages/ on the host without rebuilding the image.
-            # Rebuild (`pnpm docker:build`) is still required after package.json / lockfile / Dockerfile changes.
-            - ./app:/app/app
-            - ./packages:/app/packages
-            # Keep image node_modules and a container-local .next (host cache breaks Turbopack).
-            - /app/app/node_modules
-            - /app/app/.next
         depends_on:
             mongodb:
                 condition: service_healthy

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -2,7 +2,7 @@
 # Workspace package @tap/units lives in packages/ — must be copied or the
 # pnpm workspace symlink is dangling and Turbopack fails with
 # "Module not found: Can't resolve '@tap/units'".
-FROM node:20-slim
+FROM node:24-slim
 
 WORKDIR /app
 
@@ -26,4 +26,5 @@ EXPOSE 3000
 # such as http://localhost:8293 — not the compose DNS name "server".
 # Compose overrides this with --hostname 0.0.0.0 and bind-mounts app/ + packages/
 # so source edits hot-reload without an image rebuild.
-CMD ["pnpm", "dev", "--hostname", "0.0.0.0"]
+# Webpack in Docker: Turbopack 16.2 + pnpm workspace root fails with MODULE_UNPARSABLE on next/document.
+CMD ["pnpm", "dev", "--hostname", "0.0.0.0", "--webpack"]

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -19,12 +19,20 @@ RUN pnpm install --filter tap-app... --frozen-lockfile
 
 WORKDIR /app/app
 
+# Inlined at `next build`. Compose passes docker-network values (API = http://server:8293).
+ARG NEXT_PUBLIC_API_URL=http://localhost:8293
+ARG NEXT_PUBLIC_FACTORY_ADDRESS
+ARG NEXT_PUBLIC_CHAIN_ID=98866
+ARG NEXT_PUBLIC_OPERATOR_ADDRESS
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_FACTORY_ADDRESS=$NEXT_PUBLIC_FACTORY_ADDRESS
+ENV NEXT_PUBLIC_CHAIN_ID=$NEXT_PUBLIC_CHAIN_ID
+ENV NEXT_PUBLIC_OPERATOR_ADDRESS=$NEXT_PUBLIC_OPERATOR_ADDRESS
+
+RUN pnpm build
+
 EXPOSE 3000
 
-# NEXT_PUBLIC_* must be provided at runtime via docker-compose (or build args
-# for production images). Browser API rewrite should use a host-reachable URL
-# such as http://localhost:8293 — not the compose DNS name "server".
-# Compose overrides this with --hostname 0.0.0.0 and bind-mounts app/ + packages/
-# so source edits hot-reload without an image rebuild.
-# Webpack in Docker: Turbopack 16.2 + pnpm workspace root fails with MODULE_UNPARSABLE on next/document.
-CMD ["pnpm", "dev", "--hostname", "0.0.0.0", "--webpack"]
+# `next start` — no webpack/turbopack file watcher (polling that on a bind mount pegged ~8 cores).
+# Hot reload stays on the host: pnpm app:dev.
+CMD ["pnpm", "start", "--hostname", "0.0.0.0"]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,5 +1,5 @@
 # TAP Cap Table - API Server
-FROM node:20-slim
+FROM node:24-slim
 
 WORKDIR /app
 

--- a/docs/src/pages/development/install.mdx
+++ b/docs/src/pages/development/install.mdx
@@ -11,7 +11,7 @@ You'll need these installed to start building:
 curl -L https://foundry.paradigm.xyz | bash
 ```
 
-- [Node.js](https://nodejs.org/en/download/) — required to run the server and app
+- [Node.js 24](https://nodejs.org/en/download/) — required to run the server and app (Docker images use `node:24-slim`)
 - [pnpm](https://pnpm.io/installation) — the package manager used throughout this project
 - [MongoDB Compass](https://www.mongodb.com/try/download/compass) — optional GUI for inspecting the database during development
 

--- a/docs/src/pages/development/run-server.mdx
+++ b/docs/src/pages/development/run-server.mdx
@@ -23,7 +23,7 @@ pnpm bootstrap
 # or mongo+server only: SKIP_APP=1 pnpm bootstrap
 ```
 
-Rebuild after dependency, lockfile, contract artifact, or Dockerfile changes: `pnpm docker:build`. App **source** edits do not need a rebuild — compose bind-mounts `app/` and `packages/` and polls for changes. Wallet work still prefers host `pnpm app:dev` (`app/.env.local`).
+Rebuild after app source, env, or Dockerfile changes: `pnpm docker:build`. The Docker app is `next start` (no file watcher). Wallet work still prefers host `pnpm app:dev` (`app/.env.local`).
 
 ### Check the API
 

--- a/scripts/bootstrap-plume.sh
+++ b/scripts/bootstrap-plume.sh
@@ -148,7 +148,7 @@ echo "========================"
 echo "🎉 Bootstrap complete."
 echo "  Server API:   $API_URL"
 echo "  Mongo (host): localhost:${MONGO_PORT:-27027}  (not 27017; Compass: mongodb://tap:tap@localhost:${MONGO_PORT:-27027})"
-echo "  App (Docker): http://localhost:3000  (optional; source bind-mounted — no rebuild for app/ edits)"
+echo "  App (Docker): http://localhost:3000  (optional; next start — rebuild after app source changes)"
 echo "  Product UI:   pnpm app:dev  →  http://localhost:3000/app  (reads app/.env.local)"
 echo ""
 


### PR DESCRIPTION
## What?

Docker app + server images use `node:24-slim`. The July app image is gone.

Docker app is now **`next start`** (no webpack/turbopack watcher). `next dev --webpack` plus bind-mount polling was ~800% CPU.

## Why?

Old image was Node 20 / stale UI. Watch polling on a Docker Desktop bind mount pegged the machine.

## How?

`FROM node:24-slim`. Image `pnpm build` then `pnpm start`. Hot reload stays `pnpm app:dev` on the host. Rebuild the image after app source or `NEXT_PUBLIC_*` changes.
